### PR TITLE
Fix crashes & odd behaviours on installs with capitalized folder names + queue item display bug

### DIFF
--- a/app/src/main/java/me/devsaki/hentoid/util/Helper.java
+++ b/app/src/main/java/me/devsaki/hentoid/util/Helper.java
@@ -422,4 +422,14 @@ public final class Helper {
             this.code = code;
         }
     }
+
+    public static String capitalize(String s)
+    {
+        if (null == s || 0 == s.length()) return s;
+        else if (1 == s.length()) return s.toUpperCase();
+        else
+        {
+            return s.substring(0,1).toUpperCase() + s.substring(1);
+        }
+    }
 }

--- a/app/src/main/res/layout/item_queue.xml
+++ b/app/src/main/res/layout/item_queue.xml
@@ -54,7 +54,8 @@
             <ImageView
                 android:id="@+id/ivCover"
                 android:layout_width="100dp"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
+                android:scaleType="centerInside"
                 android:padding="1dp"
                 tools:ignore="ContentDescription"
                 tools:src="@drawable/ic_placeholder" />


### PR DESCRIPTION
- Fix crashes & odd behaviours (e.g. creating one folder per page) when using old installs with capitalized folder names (e.g. Tsumino instead of tsumino)
- Fix queue item display bug