### PR TITLE
Stability fixes from beta test

### DIFF
--- a/app/src/main/java/me/devsaki/hentoid/abstracts/DownloadsFragment.java
+++ b/app/src/main/java/me/devsaki/hentoid/abstracts/DownloadsFragment.java
@@ -577,8 +577,9 @@ public abstract class DownloadsFragment extends BaseFragment implements ContentL
                 // Show toolbar:
                 if (!override && mAdapter.getItemCount() > 0) {
                     // At top of list
-                    if (llm.findViewByPosition(llm.findFirstVisibleItemPosition())
-                            .getTop() == 0 && llm.findFirstVisibleItemPosition() == 0) {
+                    int firstVisibleItemPos = llm.findFirstVisibleItemPosition();
+                    View topView = llm.findViewByPosition(firstVisibleItemPos);
+                    if (topView != null && topView.getTop() == 0 && firstVisibleItemPos == 0) {
                         showToolbar(true, false);
                         if (isNewContentAvailable) {
                             newContentToolTip.setVisibility(View.VISIBLE);

--- a/app/src/main/java/me/devsaki/hentoid/activities/AboutActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/AboutActivity.java
@@ -35,7 +35,7 @@ public class AboutActivity extends BaseActivity {
         bindTextViewLink(R.id.tv_reddit, R.string.about_reddit_url);
 
         TextView tvVersionName = findViewById(R.id.tv_version_name);
-        tvVersionName.setText("Hentoid ver: " + BuildConfig.VERSION_NAME);
+        tvVersionName.setText(String.format("Hentoid ver: %s", BuildConfig.VERSION_NAME));
 
         WebView webView = new WebView(this);
         webView.loadUrl("file:///android_asset/licenses.html");

--- a/app/src/main/java/me/devsaki/hentoid/activities/websites/BaseWebActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/websites/BaseWebActivity.java
@@ -319,7 +319,7 @@ public abstract class BaseWebActivity extends BaseActivity {
     }
 
     /**
-     * Adds current content (i.e. content of the currently viewed book) to the download queue
+     * Add current content (i.e. content of the currently viewed book) to the download queue
      */
     void processDownload() {
         currentContent = db.selectContentById(currentContent.getId());

--- a/app/src/main/java/me/devsaki/hentoid/activities/websites/BaseWebActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/websites/BaseWebActivity.java
@@ -44,6 +44,7 @@ import me.devsaki.hentoid.enums.StatusContent;
 import me.devsaki.hentoid.parsers.ContentParser;
 import me.devsaki.hentoid.parsers.ContentParserFactory;
 import me.devsaki.hentoid.services.ContentDownloadService;
+import me.devsaki.hentoid.services.ContentQueueManager;
 import me.devsaki.hentoid.util.Consts;
 import me.devsaki.hentoid.util.ConstsImport;
 import me.devsaki.hentoid.util.FileHelper;
@@ -75,8 +76,8 @@ public abstract class BaseWebActivity extends BaseActivity {
     private boolean fabReadEnabled, fabDownloadEnabled;
 
     // List of blocked content (ads or annoying images) -- will be replaced by a blank stream
-    private static final List<String> universalBlockedContent = new ArrayList<>();    // Universal list (applied to all sites)
-    private List<String> localBlockedContent;                                   // Local list (applied to current site)
+    private static final List<String> universalBlockedContent = new ArrayList<>();      // Universal list (applied to all sites)
+    private List<String> localBlockedContent;                                           // Local list (applied to current site)
 
     static {
         universalBlockedContent.add("exoclick.com");
@@ -335,8 +336,7 @@ public abstract class BaseWebActivity extends BaseActivity {
         }
         db.insertQueue(currentContent.getId(), lastIndex);
 
-        Intent intent = new Intent(Intent.ACTION_SYNC, null, this, ContentDownloadService.class);
-        startService(intent);
+        ContentQueueManager.getInstance().resumeQueue(this);
 
         hideFab(fabDownload);
     }

--- a/app/src/main/java/me/devsaki/hentoid/activities/websites/TsuminoActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/websites/TsuminoActivity.java
@@ -22,7 +22,7 @@ public class TsuminoActivity extends BaseWebActivity {
 
     private boolean downloadFabPressed = false;
     private int historyIndex;
-    private static final String[] blockedContent = {"/content/"};
+    private static final String[] blockedContent = {"/static/"};
 
 
     private static int ordinalIndexOf(String str) {

--- a/app/src/main/java/me/devsaki/hentoid/database/constants/ContentTable.java
+++ b/app/src/main/java/me/devsaki/hentoid/database/constants/ContentTable.java
@@ -83,13 +83,6 @@ public abstract class ContentTable {
 
     public static final String SELECT_NULL_FOLDERS = "SELECT * FROM " + TABLE_NAME + " WHERE " + STORAGE_FOLDER_COLUMN + " is null";
 
-    public static final String SELECT_BY_STATUS = "SELECT * FROM " + TABLE_NAME + " C WHERE C."
-            + STATUS_COLUMN + " = ? ORDER BY C." + DOWNLOAD_DATE_COLUMN;
-
-    public static final String SELECT_IN_DOWNLOAD_MANAGER = "SELECT * FROM " + TABLE_NAME + " C WHERE C."
-            + STATUS_COLUMN + " in (?, ?) ORDER BY C." + STATUS_COLUMN + ", C."
-            + DOWNLOAD_DATE_COLUMN;
-
 
     // SEARCH QUERIES "TOOLBOX"
 

--- a/app/src/main/java/me/devsaki/hentoid/database/domains/Content.java
+++ b/app/src/main/java/me/devsaki/hentoid/database/domains/Content.java
@@ -220,7 +220,7 @@ public class Content implements Serializable {
 
     public void populateAuthor() {
         String author = "";
-        if (attributes.containsKey(AttributeType.ARTIST) && attributes.get(AttributeType.ARTIST).size() > 0)
+        if (getAttributes().containsKey(AttributeType.ARTIST) && attributes.get(AttributeType.ARTIST).size() > 0)
             author = attributes.get(AttributeType.ARTIST).get(0).getName();
         if (author.equals("")) // Try and get Circle
         {

--- a/app/src/main/java/me/devsaki/hentoid/database/domains/Content.java
+++ b/app/src/main/java/me/devsaki/hentoid/database/domains/Content.java
@@ -19,6 +19,7 @@ import me.devsaki.hentoid.enums.AttributeType;
 import me.devsaki.hentoid.enums.Site;
 import me.devsaki.hentoid.enums.StatusContent;
 import me.devsaki.hentoid.util.AttributeMap;
+import me.devsaki.hentoid.util.FileHelper;
 
 /**
  * Created by DevSaki on 09/05/2015.
@@ -108,7 +109,7 @@ public class Content implements Serializable {
             case HITOMI:
                 paths = url.split("/");
                 return paths[1].replace(".html", "") + "-" +
-                        title.replaceAll("[^a-zA-Z0-9.-]", "_");
+                        title.replaceAll(FileHelper.FORBIDDEN_CHARS, "_");
             case ASMHENTAI:
             case ASMHENTAI_COMICS:
             case NHENTAI:

--- a/app/src/main/java/me/devsaki/hentoid/fragments/QueueFragment.java
+++ b/app/src/main/java/me/devsaki/hentoid/fragments/QueueFragment.java
@@ -1,7 +1,6 @@
 package me.devsaki.hentoid.fragments;
 
 import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.FragmentActivity;
@@ -27,7 +26,6 @@ import me.devsaki.hentoid.adapters.QueueContentAdapter;
 import me.devsaki.hentoid.database.domains.Content;
 import me.devsaki.hentoid.enums.StatusContent;
 import me.devsaki.hentoid.events.DownloadEvent;
-import me.devsaki.hentoid.services.ContentDownloadService;
 import me.devsaki.hentoid.services.ContentQueueManager;
 import timber.log.Timber;
 
@@ -111,8 +109,7 @@ public class QueueFragment extends BaseFragment {
             case DownloadEvent.EV_UNPAUSE:
                 ContentQueueManager.getInstance().unpauseQueue();
                 getDB().updateContentStatus(StatusContent.PAUSED, StatusContent.DOWNLOADING);
-                Intent intent = new Intent(Intent.ACTION_SYNC, null, context, ContentDownloadService.class);
-                context.startService(intent);
+                ContentQueueManager.getInstance().resumeQueue(context);
                 update(event.eventType);
                 break;
             case DownloadEvent.EV_SKIP:
@@ -196,7 +193,7 @@ public class QueueFragment extends BaseFragment {
         List<Content> contents = getDB().selectQueueContents();
 
         boolean isEmpty = (0 == contents.size());
-        boolean isPaused = (!isEmpty && (eventType == DownloadEvent.EV_PAUSE || ContentQueueManager.getInstance().isQueuePaused()));
+        boolean isPaused = (!isEmpty && (eventType == DownloadEvent.EV_PAUSE || ContentQueueManager.getInstance().isQueuePaused() || !ContentQueueManager.getInstance().isQueueActive()));
         boolean isActive = (!isEmpty && !isPaused);
 
         Timber.d("Queue state : E/P/A > %s/%s/%s -- %s elements", isEmpty, isPaused, isActive, contents.size());

--- a/app/src/main/java/me/devsaki/hentoid/services/ContentDownloadService.java
+++ b/app/src/main/java/me/devsaki/hentoid/services/ContentDownloadService.java
@@ -237,8 +237,7 @@ public class ContentDownloadService extends IntentService {
         }
 
         // Download next content in a new Intent
-        Intent intentService = new Intent(Intent.ACTION_SYNC, null, this, ContentDownloadService.class);
-        startService(intentService);
+        ContentQueueManager.getInstance().resumeQueue(this);
     }
 
     /**

--- a/app/src/main/java/me/devsaki/hentoid/services/ContentDownloadService.java
+++ b/app/src/main/java/me/devsaki/hentoid/services/ContentDownloadService.java
@@ -273,23 +273,24 @@ public class ContentDownloadService extends IntentService {
      * @return Volley request and its handler
      */
     private InputStreamVolleyRequest buildStringRequest(ImageFile img, File dir) {
-        return new InputStreamVolleyRequest(Request.Method.GET, img.getUrl(),
-                response -> {
+        return new InputStreamVolleyRequest(
+                Request.Method.GET,
+                img.getUrl(),
+                parse -> {
                     try {
-                        if (response != null) {
-                            saveImage(img.getName(), dir, response.getValue().get("Content-Type"), response.getKey());
-                            updateImageStatus(img, true);
-                        }
+                        updateImageStatus(img, (parse != null));
+                        if (parse != null) saveImage(img.getName(), dir, parse.getValue().get("Content-Type"), parse.getKey());
                     } catch (IOException e) {
-                        Timber.d("I/O error - Image %s not saved", img.getUrl());
+                        Timber.w("I/O error - Image %s not saved", img.getUrl());
                         e.printStackTrace();
                         updateImageStatus(img, false);
                     }
-                }, error -> {
-            Timber.d("Download error - Image %s not retrieved", img.getUrl());
-            error.printStackTrace();
-            updateImageStatus(img, false);
-        });
+                },
+                error -> {
+                    Timber.w("Download error - Image %s not retrieved", img.getUrl());
+                    error.printStackTrace();
+                    updateImageStatus(img, false);
+                });
     }
 
     /**

--- a/app/src/main/java/me/devsaki/hentoid/services/ContentQueueManager.java
+++ b/app/src/main/java/me/devsaki/hentoid/services/ContentQueueManager.java
@@ -1,18 +1,31 @@
 package me.devsaki.hentoid.services;
 
+import android.content.Context;
+import android.content.Intent;
+
 /**
  * Created by Robb_w on 2018/04
  * Manager class for Content (book) download queue
+ *
+ * By default at app launch :
+ *      - Queue is inactive (i.e. does not do anything)
+ *      - Queue is unpaused (i.e. will immediately start to download when activated)
+ *
+ * At first download command :
+ *      - Queue becomes active
+ *      - Queue "stays" unpaused => Download starts
  */
 public class ContentQueueManager {
     private static ContentQueueManager mInstance;   // Instance of the singleton
 
-    private boolean isQueuePaused;                  // True if queue paused; false if active
+    private boolean isQueuePaused;                  // True if queue paused; false if not
+    private boolean isQueueActive;                  // True if queue active; false if not
     private int downloadCount = 0;                  // Used to store the number of downloads completed during current session
-    // in order to display notifications correctly ("download completed" vs. "N downloads completed")
+                                                    // in order to display notifications correctly ("download completed" vs. "N downloads completed")
 
     private ContentQueueManager() {
         isQueuePaused = false;
+        isQueueActive = false;
     }
 
     public static synchronized ContentQueueManager getInstance() {
@@ -23,17 +36,21 @@ public class ContentQueueManager {
     }
 
 
-    // PAUSE CONTROL
+    // QUEUE ACTIVITY CONTROL
     public void pauseQueue() {
         isQueuePaused = true;
     }
-
     public void unpauseQueue() {
         isQueuePaused = false;
     }
+    public boolean isQueuePaused() { return isQueuePaused; }
 
-    public boolean isQueuePaused() {
-        return isQueuePaused;
+    public boolean isQueueActive() { return isQueueActive; }
+    public void resumeQueue(Context context)
+    {
+        Intent intent = new Intent(Intent.ACTION_SYNC, null, context, ContentDownloadService.class);
+        context.startService(intent);
+        isQueueActive = true;
     }
 
 

--- a/app/src/main/java/me/devsaki/hentoid/services/InputStreamVolleyRequest.java
+++ b/app/src/main/java/me/devsaki/hentoid/services/InputStreamVolleyRequest.java
@@ -18,28 +18,31 @@ import java.util.Map;
  * to the download callback routine
  */
 class InputStreamVolleyRequest extends Request<byte[]> {
-    // Callback
-    private final Response.Listener<Map.Entry<byte[], Map<String, String>>> mListener;
-    // Temporary storage for HTTP response headers
-    private Map<String, String> responseHeaders;
+    // Callback listeners
+    private final Response.Listener<Map.Entry<byte[], Map<String, String>>> mParseListener;
 
-    InputStreamVolleyRequest(int method, String mUrl, Response.Listener<Map.Entry<byte[], Map<String, String>>> listener,
-                             Response.ErrorListener errorListener) {
+    InputStreamVolleyRequest(
+            int method,
+            String mUrl,
+            Response.Listener<Map.Entry<byte[], Map<String, String>>> parseListener,
+            Response.ErrorListener errorListener) {
         super(method, mUrl, errorListener);
         // this request would never use cache.
         setShouldCache(false);
-        mListener = listener;
+        mParseListener = parseListener;
     }
 
     @Override
     protected void deliverResponse(byte[] response) {
-        mListener.onResponse(new AbstractMap.SimpleEntry<>(response, responseHeaders));
+        // Nothing; all the work is done in Volley's worker thread, since it is time consuming (picture saving + DB operations)
     }
 
     @Override
     protected Response<byte[]> parseNetworkResponse(NetworkResponse response) {
         //Initialise local responseHeaders map with response headers received
-        responseHeaders = response.headers;
+        Map<String, String> responseHeaders = response.headers;
+
+        mParseListener.onResponse(new AbstractMap.SimpleEntry<>(response.data, responseHeaders));
 
         //Pass the response data here
         return Response.success(response.data, HttpHeaderParser.parseCacheHeaders(response));

--- a/app/src/main/java/me/devsaki/hentoid/services/RequestQueueManager.java
+++ b/app/src/main/java/me/devsaki/hentoid/services/RequestQueueManager.java
@@ -39,7 +39,8 @@ public class RequestQueueManager implements RequestQueue.RequestFinishedListener
      */
     private RequestQueue getRequestQueue(Context ctx) {
         if (mRequestQueue == null) {
-            mRequestQueue = Volley.newRequestQueue(ctx.getApplicationContext(), new VolleyOkHttp3Stack());
+            int TIMEOUT_MS = 15000;
+            mRequestQueue = Volley.newRequestQueue(ctx.getApplicationContext(), new VolleyOkHttp3Stack(TIMEOUT_MS));
             mRequestQueue.addRequestFinishedListener(this);
         }
         return mRequestQueue;

--- a/app/src/main/java/me/devsaki/hentoid/util/FileHelper.java
+++ b/app/src/main/java/me/devsaki/hentoid/util/FileHelper.java
@@ -38,6 +38,8 @@ public class FileHelper {
     // Note that many devices will report true (there are no guarantees of this being 'external')
     public static final boolean isSDPresent = getExternalStorageState().equals(MEDIA_MOUNTED);
 
+    public static final String FORBIDDEN_CHARS = "[^a-zA-Z0-9.-]";
+
     private static final String AUTHORITY = BuildConfig.APPLICATION_ID + ".provider.FileProvider";
 
     public static void saveUri(Uri uri) {
@@ -280,10 +282,10 @@ public class FileHelper {
         int folderNamingPreference = Preferences.getFolderNameFormat();
 
         if (folderNamingPreference == Preferences.Constant.PREF_FOLDER_NAMING_CONTENT_AUTH_TITLE_ID) {
-            folderDir = folderDir + content.getAuthor().replaceAll("[^a-zA-Z0-9.-]", "_") + " - ";
+            folderDir = folderDir + content.getAuthor().replaceAll(FORBIDDEN_CHARS, "_") + " - ";
         }
         if (folderNamingPreference == Preferences.Constant.PREF_FOLDER_NAMING_CONTENT_AUTH_TITLE_ID || folderNamingPreference == Preferences.Constant.PREF_FOLDER_NAMING_CONTENT_TITLE_ID) {
-            folderDir = folderDir + content.getTitle().replaceAll("[^a-zA-Z0-9.-]", "_") + " - ";
+            folderDir = folderDir + content.getTitle().replaceAll(FORBIDDEN_CHARS, "_") + " - ";
         }
         folderDir = folderDir + "[" + content.getUniqueSiteId() + "]";
 

--- a/app/src/main/java/me/devsaki/hentoid/util/FileHelper.java
+++ b/app/src/main/java/me/devsaki/hentoid/util/FileHelper.java
@@ -484,11 +484,8 @@ public class FileHelper {
             }
 
             // Build destination file
-            File dest = new File(context.getExternalCacheDir() + "/shared/%s",
-                    content.getTitle()
-                            .replaceAll("[\\?\\\\/:|<>\\*]", " ")  //filter ? \ / : | < > *
-                            .replaceAll("\\s+", "_")  // white space as underscores
-                            + ".zip");
+            File dest = new File(context.getExternalCacheDir() + "/shared",
+                    content.getTitle().replaceAll(FORBIDDEN_CHARS, "_") + ".zip");
             Timber.d("Destination file: %s", dest);
 
             // Convert ArrayList to Array

--- a/app/src/main/java/me/devsaki/hentoid/util/FileUtil.java
+++ b/app/src/main/java/me/devsaki/hentoid/util/FileUtil.java
@@ -150,7 +150,7 @@ class FileUtil {
         try {
             return FileUtils.openOutputStream(target);
         } catch (IOException e) {
-            Timber.d(e, "Could not open file");
+            Timber.d(e, "Could not open file"); // TODO do something for not displaying that exception on logcat, since it is "expected"
         }
 
         try {

--- a/app/src/main/java/me/devsaki/hentoid/util/NetworkStatus.java
+++ b/app/src/main/java/me/devsaki/hentoid/util/NetworkStatus.java
@@ -59,8 +59,8 @@ public final class NetworkStatus {
                         (new URL("http://clients3.google.com/generate_204").openConnection());
                 url.setRequestProperty("User-Agent", "Android");
                 url.setRequestProperty("Connection", "close");
-                url.setConnectTimeout(100);
-                url.setReadTimeout(100);
+                url.setConnectTimeout(1500);
+                url.setReadTimeout(1500);
                 url.connect();
 
                 return (url.getResponseCode() == 204 && url.getContentLength() == 0);

--- a/app/src/main/java/me/devsaki/hentoid/util/VolleyOkHttp3Stack.java
+++ b/app/src/main/java/me/devsaki/hentoid/util/VolleyOkHttp3Stack.java
@@ -22,15 +22,25 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 
 /**
- * Created by Robb_w in 2018/04; heavily inspired by https://gist.github.com/alashow/c96c09320899e4caa06b
+ * Created by Robb_w in 2018/04; heavily inspired by
+ *      https://gist.github.com/LOG-TAG/3ad1c191b3ca7eab3ea6834386e30eb9
+ *     and
+ *      https://gist.github.com/JakeWharton/5616899
  *
  *  okhttp wrapper for Volley; allows the use of okhttp as low-level network operations handler by Volley
  *  The main reason being okhttp's ability to automatically follow 301 & 302's while default Volley handler cannot
  */
 public class VolleyOkHttp3Stack extends BaseHttpStack {
 
-    public VolleyOkHttp3Stack() {
+    private final OkHttpClient client;
 
+    public VolleyOkHttp3Stack(int timeoutMs) {
+        OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
+        clientBuilder.connectTimeout(timeoutMs, TimeUnit.MILLISECONDS);
+        clientBuilder.readTimeout(timeoutMs, TimeUnit.MILLISECONDS);
+        clientBuilder.writeTimeout(timeoutMs, TimeUnit.MILLISECONDS);
+
+        client = clientBuilder.build();
     }
 
     private static void setConnectionParametersForRequest(okhttp3.Request.Builder builder, Request<?> request)
@@ -82,13 +92,6 @@ public class VolleyOkHttp3Stack extends BaseHttpStack {
 
     @Override
     public HttpResponse executeRequest(Request<?> request, Map<String, String> additionalHeaders) throws IOException, AuthFailureError {
-        OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
-        int timeoutMs = request.getTimeoutMs();
-
-        clientBuilder.connectTimeout(timeoutMs, TimeUnit.MILLISECONDS);
-        clientBuilder.readTimeout(timeoutMs, TimeUnit.MILLISECONDS);
-        clientBuilder.writeTimeout(timeoutMs, TimeUnit.MILLISECONDS);
-
         okhttp3.Request.Builder okHttpRequestBuilder = new okhttp3.Request.Builder();
         okHttpRequestBuilder.url(request.getUrl());
 
@@ -102,7 +105,6 @@ public class VolleyOkHttp3Stack extends BaseHttpStack {
 
         setConnectionParametersForRequest(okHttpRequestBuilder, request);
 
-        OkHttpClient client = clientBuilder.build();
         okhttp3.Request okHttpRequest = okHttpRequestBuilder.build();
         Call okHttpCall = client.newCall(okHttpRequest);
         Response okHttpResponse = okHttpCall.execute();

--- a/app/src/main/res/layout/intro_slide_02_alt.xml
+++ b/app/src/main/res/layout/intro_slide_02_alt.xml
@@ -51,5 +51,5 @@
 
     <TextView
         android:layout_width="fill_parent"
-        android:layout_height="64dp" />
+        android:layout_height="24dp" />
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,7 +103,7 @@
     <string name="pin_ok">PIN OK!</string>
     <!-- About Activity -->
     <string name="about1"><b>Hentoid</b> is a Doujinshi &amp; H-Manga archiving app. Hentoid was originally created by <b>Cesar Arasaki</b>.</string>
-    <string name="about2">In regards to tsumino - you will need to solve the captcha for now, but we are experimenting with other methods as well.</string>
+    <string name="about2">In regards to Tsumino - you will need to solve the captcha for now, but we are experimenting with other methods as well.</string>
     <string name="about_community" translatable="false"><u>Google+</u></string>
     <string name="about_community_url" translatable="false">https://plus.google.com/communities/110496467189870321840</string>
     <string name="about_github" translatable="false"><u>GitHub</u></string>

--- a/app/src/main/res/values/strings_slides.xml
+++ b/app/src/main/res/values/strings_slides.xml
@@ -8,7 +8,7 @@
     <string name="slide_02_text">Got Marshmallows?\nWe need to ask you for permission to device storage.</string>
     <!-- Slide 02 Alt -->
     <string name="slide_02_alt_header">What to expect?</string>
-    <string name="slide_02_alt_text">Hentoid supports:\nNhentai, Hitomi, Tsumino\n&amp; archived content from\nFAKKU and Pururin.</string>
+    <string name="slide_02_alt_text">Hentoid supports:\nNhentai, Hitomi, Tsumino, Hentai Cafe, ASM Hentai (manga &amp; comics) and Pururin\n&amp; archived content from\nFAKKU and Pururin.</string>
     <!-- Slide 03 -->
     <string name="slide_03_header">Storage Folder</string>
     <string name="slide_03_text">Hentoid requires a dedicated folder for storing your media.</string>


### PR DESCRIPTION
- Fix out of memory errors during download caused by improper initialization of OkHttpClient
- Fix image downloads slowing down / freezing main thread 
- Fix crash when importing a book without any attributes in its JSON 
- Fix error when exporting book as ZIP archive
- Prevent the queue from being displayed as active when there are books left to download at app startup
- Fix wrong content (ad) filter for Tsumino
- Fix rare crash when turning device orientation while typing on nHentai search bar (thanks Cat Knight)
- Extend timeout delay for network connectivity check