### PR TITLE
Fix weak warnings

### DIFF
--- a/app/src/main/java/me/devsaki/hentoid/database/domains/Content.java
+++ b/app/src/main/java/me/devsaki/hentoid/database/domains/Content.java
@@ -9,6 +9,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 import io.objectbox.annotation.Backlink;
 import io.objectbox.annotation.Convert;
@@ -589,12 +590,13 @@ public class Content implements Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof Content)) {
+            return false;
+        }
 
         Content content = (Content) o;
 
-        return (url != null ? url.equals(content.url) : content.url == null) && site == content.site;
+        return this == o || Objects.equals(content.url, url) && Objects.equals(content.site, site);
     }
 
     @Override

--- a/app/src/main/java/me/devsaki/hentoid/database/domains/Content.java
+++ b/app/src/main/java/me/devsaki/hentoid/database/domains/Content.java
@@ -596,7 +596,7 @@ public class Content implements Serializable {
 
         Content content = (Content) o;
 
-        return this == o || Objects.equals(content.url, url) && Objects.equals(content.site, site);
+        return this == o || (Objects.equals(content.url, url) && Objects.equals(content.site, site));
     }
 
     @Override

--- a/app/src/main/java/me/devsaki/hentoid/dirpicker/events/CurrentRootDirChangedEvent.java
+++ b/app/src/main/java/me/devsaki/hentoid/dirpicker/events/CurrentRootDirChangedEvent.java
@@ -1,6 +1,7 @@
 package me.devsaki.hentoid.dirpicker.events;
 
 import java.io.File;
+import java.util.Objects;
 
 /**
  * Created by avluis on 06/11/2016.
@@ -19,17 +20,13 @@ public class CurrentRootDirChangedEvent {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof CurrentRootDirChangedEvent)) {
             return false;
         }
 
         CurrentRootDirChangedEvent event = (CurrentRootDirChangedEvent) o;
 
-        return currentDir != null ? currentDir.equals(event.currentDir) : event.currentDir == null;
+        return this == o || Objects.equals(event.currentDir, currentDir);
     }
 
     @Override

--- a/app/src/main/java/me/devsaki/hentoid/dirpicker/events/UpdateDirTreeEvent.java
+++ b/app/src/main/java/me/devsaki/hentoid/dirpicker/events/UpdateDirTreeEvent.java
@@ -1,6 +1,7 @@
 package me.devsaki.hentoid.dirpicker.events;
 
 import java.io.File;
+import java.util.Objects;
 
 /**
  * Created by avluis on 06/11/2016.
@@ -15,17 +16,13 @@ public class UpdateDirTreeEvent {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof UpdateDirTreeEvent)) {
             return false;
         }
 
         UpdateDirTreeEvent event = (UpdateDirTreeEvent) o;
 
-        return rootDir != null ? rootDir.equals(event.rootDir) : event.rootDir == null;
+        return this == o || Objects.equals(event.rootDir, rootDir);
     }
 
     @Override


### PR DESCRIPTION
Fix weak warnings detected by android studio using this site as a reference
https://www.geeksforgeeks.org/java-util-objects-class-java/
obs: Content method seems wrong to just compare if their are referencing the same object or if only those two atributes from all the ones Content has are equal.