### PR TITLE
fixes #352

### DIFF
--- a/app/src/main/java/me/devsaki/hentoid/parsers/content/NhentaiContent.java
+++ b/app/src/main/java/me/devsaki/hentoid/parsers/content/NhentaiContent.java
@@ -53,7 +53,7 @@ public class NhentaiContent implements ContentParser {
         String theUrl = galleryUrl.isEmpty() ? url : galleryUrl;
         if (theUrl.isEmpty()) return result.setStatus(StatusContent.IGNORED);
 
-        result.setUrl(theUrl.replace("/g", "").replace("1/", ""));
+        result.setUrl(theUrl.replace("/g", "").replaceFirst("1/", ""));
         result.setCoverImageUrl(coverUrl);
         result.setTitle(title);
 

--- a/app/src/main/java/me/devsaki/hentoid/parsers/content/NhentaiContent.java
+++ b/app/src/main/java/me/devsaki/hentoid/parsers/content/NhentaiContent.java
@@ -53,7 +53,7 @@ public class NhentaiContent implements ContentParser {
         String theUrl = galleryUrl.isEmpty() ? url : galleryUrl;
         if (theUrl.isEmpty()) return result.setStatus(StatusContent.IGNORED);
 
-        result.setUrl(theUrl.replace("/g", "").replaceFirst("1/", ""));
+        result.setUrl(theUrl.replace("/g", "").replace("1\\/$", ""));
         result.setCoverImageUrl(coverUrl);
         result.setTitle(title);
 

--- a/app/src/main/java/me/devsaki/hentoid/parsers/content/NhentaiContent.java
+++ b/app/src/main/java/me/devsaki/hentoid/parsers/content/NhentaiContent.java
@@ -53,7 +53,7 @@ public class NhentaiContent implements ContentParser {
         String theUrl = galleryUrl.isEmpty() ? url : galleryUrl;
         if (theUrl.isEmpty()) return result.setStatus(StatusContent.IGNORED);
 
-        result.setUrl(theUrl.replace("/g", "").replace("1\\/$", ""));
+        result.setUrl(theUrl.replace("/g", "").replaceFirst("/1/$", "/"));
         result.setCoverImageUrl(coverUrl);
         result.setTitle(title);
 


### PR DESCRIPTION
the site url of nhentai books was being affected by this bug because result.setUrl using the gallery url to get it's value what this entail is the following:
-Before correction:
https://nhentai.net/g/99991/1/
became
https://nhentai.net/g/9999
-After correction:
https://nhentai.net/g/99991/1/
becomes
https://nhentai.net/g/99991/
i tested downloading books that had the code 99991, 11, 1 and the one reported by the user 176361 all of them downloaded without errors and redirected in queue and download library to the correct book.
