### PR TITLE
Localization: Cleanup [3]

### DIFF
--- a/app/src/main/res/values-ru/array_preferences.xml
+++ b/app/src/main/res/values-ru/array_preferences.xml
@@ -9,11 +9,11 @@
     <!-- Выбор порога для уведомления о заполненной памяти -->
     <string name="pref_memory_alert_entries_1">Не уведомлять</string>
     <!-- Выбор порога для уведомления о заполненной памяти -->
-    <string name="pref_memory_alert_entries_2">когда заполнена на 90%%</string>
+    <string name="pref_memory_alert_entries_2">когда заполнена на 90%</string>
     <!-- Выбор порога для уведомления о заполненной памяти -->
-    <string name="pref_memory_alert_entries_3">когда заполнена на 95%%</string>
+    <string name="pref_memory_alert_entries_3">когда заполнена на 95%</string>
     <!-- Выбор порога для уведомления о заполненной памяти -->
-    <string name="pref_memory_alert_entries_4">когда заполнена на 98%%</string>
+    <string name="pref_memory_alert_entries_4">когда заполнена на 98%</string>
     <!-- Выбор значения порога для активации долгого нажатия -->
     <string name="pref_browser_quick_dl_threshold_entries_1">500 мс (по умолчанию)</string>
     <!-- Выбор значения порога для активации долгого нажатия -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" xmlns:x="urn:oasis:names:tc:xliff:document:1.2">
     <!-- Generic usage -->
-    <string name="app_name">Hentoid</string>
     <string name="app_intro">Добро пожаловать</string>
     <!-- because Android default "OK" value for "yes" key is nonsense -->
     <string name="yes">Да</string>

--- a/app/src/main/res/values/array_preferences.xml
+++ b/app/src/main/res/values/array_preferences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- DO NOT modify the way these arrays are set up - it is required for Weblate to work -->
     <!-- see https://docs.weblate.org/en/latest/formats.html#android-string-resources -->
     <string-array name="pref_library_display_entries" translatable="false">
@@ -43,11 +43,11 @@
     <!-- Choice for "Alert on low memory" setting -->
     <string name="pref_memory_alert_entries_1">No alert</string>
     <!-- Choice for "Alert on low memory" setting -->
-    <string name="pref_memory_alert_entries_2">on 90%% full</string>
+    <string name="pref_memory_alert_entries_2">on 90% full</string>
     <!-- Choice for "Alert on low memory" setting -->
-    <string name="pref_memory_alert_entries_3">on 95%% full</string>
+    <string name="pref_memory_alert_entries_3">on 95% full</string>
     <!-- Choice for "Alert on low memory" setting -->
-    <string name="pref_memory_alert_entries_4">on 98%% full</string>
+    <string name="pref_memory_alert_entries_4">on 98% full</string>
     <string-array name="pref_browser_quick_dl_threshold_entries" translatable="false">
         <item>@string/pref_browser_quick_dl_threshold_entries_1</item>
         <item>@string/pref_browser_quick_dl_threshold_entries_2</item>
@@ -65,13 +65,13 @@
     <!-- Choice for "Quick download long press threshold" setting -->
     <string name="pref_browser_quick_dl_threshold_entries_1">500 ms (default)</string>
     <!-- Choice for "Quick download long press threshold" setting -->
-    <string name="pref_browser_quick_dl_threshold_entries_2">1 s</string>
+    <string name="pref_browser_quick_dl_threshold_entries_2" tools:ignore="MissingTranslation">1 s</string>
     <!-- Choice for "Quick download long press threshold" setting -->
-    <string name="pref_browser_quick_dl_threshold_entries_3">1.5 s</string>
+    <string name="pref_browser_quick_dl_threshold_entries_3" tools:ignore="MissingTranslation">1.5 s</string>
     <!-- Choice for "Quick download long press threshold" setting -->
-    <string name="pref_browser_quick_dl_threshold_entries_4">2 s</string>
+    <string name="pref_browser_quick_dl_threshold_entries_4" tools:ignore="MissingTranslation">2 s</string>
     <!-- Choice for "Quick download long press threshold" setting -->
-    <string name="pref_browser_quick_dl_threshold_entries_5">3 s</string>
+    <string name="pref_browser_quick_dl_threshold_entries_5" tools:ignore="MissingTranslation">3 s</string>
     <string-array name="pref_browser_dns_entries" translatable="false">
         <item>@string/pref_browser_dns_entries_1</item>
         <item>Cloudflare</item>
@@ -119,13 +119,13 @@
     <!-- Choice for "Large downloads size threshold" setting -->
     <string name="pref_dl_size_wifi_threshold_entries_1">No size limit</string>
     <!-- Choice for "Large downloads size threshold" setting -->
-    <string name="pref_dl_size_wifi_threshold_entries_2">20 MB</string>
+    <string name="pref_dl_size_wifi_threshold_entries_2" tools:ignore="MissingTranslation">20 MB</string>
     <!-- Choice for "Large downloads size threshold" setting -->
-    <string name="pref_dl_size_wifi_threshold_entries_3">40 MB</string>
+    <string name="pref_dl_size_wifi_threshold_entries_3" tools:ignore="MissingTranslation">40 MB</string>
     <!-- Choice for "Large downloads size threshold" setting -->
-    <string name="pref_dl_size_wifi_threshold_entries_4">100 MB</string>
+    <string name="pref_dl_size_wifi_threshold_entries_4" tools:ignore="MissingTranslation">100 MB</string>
     <!-- Choice for "Large downloads size threshold" setting -->
-    <string name="pref_dl_size_wifi_threshold_entries_5">200 MB</string>
+    <string name="pref_dl_size_wifi_threshold_entries_5" tools:ignore="MissingTranslation">200 MB</string>
     <string-array name="pref_dl_pages_wifi_threshold_entries" translatable="false">
         <item>@string/pref_dl_pages_wifi_threshold_entries_1</item>
         <item>@string/pref_dl_pages_wifi_threshold_entries_2</item>
@@ -185,7 +185,7 @@
         <item>3</item>
     </string-array>
     <!-- Choice for "Book folder naming convention" setting -->
-    <string name="pref_folder_naming_content_entries_1">ID</string>
+    <string name="pref_folder_naming_content_entries_1" tools:ignore="MissingTranslation">ID</string>
     <!-- Choice for "Book folder naming convention" setting -->
     <string name="pref_folder_naming_content_entries_2">Title - ID</string>
     <!-- Choice for "Book folder naming convention" setting -->
@@ -270,9 +270,9 @@
         <item>5</item>
     </string-array>
     <string-array name="pref_dl_retries_mem_limit_entries" translatable="false">
-        <item>90%%</item>
-        <item>95%%</item>
-        <item>98%%</item>
+        <item>90%</item>
+        <item>95%</item>
+        <item>98%</item>
         <item>@string/pref_dl_retries_mem_limit_entries_4</item>
     </string-array>
     <string-array name="pref_dl_retries_mem_limit_values" translatable="false">
@@ -368,17 +368,17 @@
         <item>3</item>
     </string-array>
     <!-- Choice for "Slideshow delay" setting -->
-    <string name="pref_viewer_slideshow_delay_entries_1">500 ms</string>
+    <string name="pref_viewer_slideshow_delay_entries_1" tools:ignore="MissingTranslation">500 ms</string>
     <!-- Choice for "Slideshow delay" setting -->
-    <string name="pref_viewer_slideshow_delay_entries_2">1 s</string>
+    <string name="pref_viewer_slideshow_delay_entries_2" tools:ignore="MissingTranslation">1 s</string>
     <!-- Choice for "Slideshow delay" setting -->
     <string name="pref_viewer_slideshow_delay_entries_3">2 s (default)</string>
     <!-- Choice for "Slideshow delay" setting -->
-    <string name="pref_viewer_slideshow_delay_entries_4">4 s</string>
+    <string name="pref_viewer_slideshow_delay_entries_4" tools:ignore="MissingTranslation">4 s</string>
     <!-- Choice for "Slideshow delay" setting -->
-    <string name="pref_viewer_slideshow_delay_entries_5">8 s</string>
+    <string name="pref_viewer_slideshow_delay_entries_5" tools:ignore="MissingTranslation">8 s</string>
     <!-- Choice for "Slideshow delay" setting -->
-    <string name="pref_viewer_slideshow_delay_entries_6">16 s</string>
+    <string name="pref_viewer_slideshow_delay_entries_6" tools:ignore="MissingTranslation">16 s</string>
     <string-array name="pref_viewer_display_mode_entries" translatable="false">
         <item>@string/pref_viewer_display_mode_entries_1</item>
         <item>@string/pref_viewer_display_mode_entries_2</item>
@@ -422,11 +422,11 @@
     <!-- Choice for "Cap double & long tap zoom" setting -->
     <string name="pref_viewer_cap_tap_zoom_entries_1">No capping</string>
     <!-- Choice for "Cap double & long tap zoom" setting -->
-    <string name="pref_viewer_cap_tap_zoom_entries_2">2x</string>
+    <string name="pref_viewer_cap_tap_zoom_entries_2" tools:ignore="MissingTranslation">2x</string>
     <!-- Choice for "Cap double & long tap zoom" setting -->
-    <string name="pref_viewer_cap_tap_zoom_entries_3">4x</string>
+    <string name="pref_viewer_cap_tap_zoom_entries_3" tools:ignore="MissingTranslation">4x</string>
     <!-- Choice for "Cap double & long tap zoom" setting -->
-    <string name="pref_viewer_cap_tap_zoom_entries_4">6x</string>
+    <string name="pref_viewer_cap_tap_zoom_entries_4" tools:ignore="MissingTranslation">6x</string>
     <string-array name="pref_viewer_gallery_columns_values" translatable="false">
         <item>2</item>
         <item>3</item>
@@ -443,11 +443,11 @@
     <!-- Choice for "Lock timer" setting -->
     <string name="pref_lock_timer_entries_1">No delay</string>
     <!-- Choice for "Lock timer" setting -->
-    <string name="pref_lock_timer_entries_2">10 s</string>
+    <string name="pref_lock_timer_entries_2" tools:ignore="MissingTranslation">10 s</string>
     <!-- Choice for "Lock timer" setting -->
     <string name="pref_lock_timer_entries_3">30 s (default)</string>
     <!-- Choice for "Lock timer" setting -->
-    <string name="pref_lock_timer_entries_4">1 min</string>
+    <string name="pref_lock_timer_entries_4" tools:ignore="MissingTranslation">1 min</string>
     <!-- Choice for "Lock timer" setting -->
     <string name="pref_lock_timer_entries_5">2 mins</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" xmlns:x="urn:oasis:names:tc:xliff:document:1.2">
     <!-- Generic usage -->
-    <string name="app_name">Hentoid</string>
+    <string name="app_name" translatable="false">Hentoid</string>
     <string name="app_id" translatable="false">me.devsaki.hentoid</string>
     <string name="app_intro">Welcome</string>
     <!-- because Android default "OK" value for "yes" key is nonsense -->
     <string name="yes">Yes</string>
     <!-- because Android default "Cancel" value for "no" key is nonsense -->
     <string name="no">No</string>
-    <string name="ok">OK</string>
+    <string name="ok" tools:ignore="MissingTranslation">OK</string>
     <string name="on">On</string>
     <string name="off">Off</string>
     <string name="select_all">Select all</string>
@@ -160,8 +160,8 @@
         <item quantity="other">(<x:g id="errors" example="2">%d</x:g> errors)</item>
     </plurals>
     <string name="queue_bottom_bar_retry">retry <x:g id="number" example="1">%1$d</x:g>/<x:g id="total" example="42">%2$d</x:g></string>
-    <string name="queue_bottom_bar_speed"><x:g id="formatted_speed_kbps" example="/102.4">%d</x:g> KBps</string>
-    <string name="download_notif_speed"><x:g id="size_dled" example="3.88">%1$d</x:g><x:g id="formatted_estimated_total" example="/14.56">%2$s</x:g> MB @ <x:g id="speed_kbps" example="102.4">%3$d</x:g> KBps</string>
+    <string name="queue_bottom_bar_speed" tools:ignore="MissingTranslation"><x:g id="formatted_speed_kbps" example="/102.4">%d</x:g> KBps</string>
+    <string name="download_notif_speed" tools:ignore="MissingTranslation"><x:g id="size_dled" example="3.88">%1$d</x:g><x:g id="formatted_estimated_total" example="/14.56">%2$s</x:g> MB @ <x:g id="speed_kbps" example="102.4">%3$d</x:g> KBps</string>
     <string name="download_notif_failed">Download failed</string>
     <string name="download_notif_failed_details">Cannot download <x:g id="book_name" example="Cool H-Manga">%1$s</x:g>: unable to create folder <x:g id="path" example="/storage/emulated/0/Hentoid/nhentai/coolhmanga">%2$s</x:g>. Please check your Hentoid folder and retry downloading using the \'!\' button.</string>
     <!-- TextViews -->
@@ -194,7 +194,7 @@
     <string name="refresh_options_remove_or">or</string>
     <!-- Delete all except favs -->
     <string name="delete_title">Delete all except favourites</string>
-    <string name="generic_progress"><x:g id="number" example="7">%1$d</x:g> / <x:g id="total" example="42">%2$d</x:g> <x:g id="type" example="books">%3$s</x:g></string>
+    <string name="generic_progress" tools:ignore="MissingTranslation"><x:g id="number" example="7">%1$d</x:g> / <x:g id="total" example="42">%2$d</x:g> <x:g id="type" example="books">%3$s</x:g></string>
     <plurals name="book_progress">
         <item quantity="one"><x:g id="number" example="1">%1$d</x:g> / <x:g id="total" example="42">%2$d</x:g> book</item>
         <item quantity="other"><x:g id="number" example="2">%1$d</x:g> / <x:g id="total" example="42">%2$d</x:g> books</item>
@@ -287,10 +287,10 @@
         <item quantity="one"><x:g id="number" example="1">%s</x:g> failed</item>
         <item quantity="other"><x:g id="number" example="2">%s</x:g> failed</item>
     </plurals>
+    <!-- for logging only -->
     <string name="enabled" translatable="false">ENABLED</string>
     <!-- for logging only -->
     <string name="disabled" translatable="false">DISABLED</string>
-    <!-- for logging only -->
     <!-- Memory usage -->
     <string name="memory_title">Memory usage</string>
     <string name="memory_total">Total: <x:g id="total" example="100 MB">%s</x:g></string>
@@ -547,8 +547,8 @@
     <string name="about_discord" translatable="false"><u>Discord</u></string>
     <string name="about_reddit" translatable="false"><u>Reddit</u></string>
     <string name="about_licenses">Display Licenses</string>
-    <string name="about_app_version">Hentoid v<x:g id="ver_name" example="1.15.20">%1$s</x:g> (<x:g id="ver_code" example="130">%2$d</x:g>)</string>
-    <string name="about_chrome_version">Chrome v<x:g id="chrome_ver" example="98">%1$d</x:g></string>
+    <string name="about_app_version" tools:ignore="MissingTranslation">Hentoid v<x:g id="ver_name" example="1.15.20">%1$s</x:g> (<x:g id="ver_code" example="130">%2$d</x:g>)</string>
+    <string name="about_chrome_version" tools:ignore="MissingTranslation">Chrome v<x:g id="chrome_ver" example="98">%1$d</x:g></string>
     <!-- Web browser -->
     <string name="web_gallery">Back to latest gallery page</string>
     <string name="web_home">Back to library</string>
@@ -794,11 +794,11 @@
     <!-- Misc -->
     <string name="select_file_manager">Select your file manager</string>
     <string name="default_permission">Default permission</string>
-    <string name="u_byte">bytes</string>
-    <string name="u_kilobyte">KB</string>
-    <string name="u_megabyte">MB</string>
-    <string name="u_gigabyte">GB</string>
-    <string name="u_terabyte">TB</string>
-    <string name="u_petabyte">PB</string>
-    <string name="u_exabyte">EB</string>
+    <string name="u_byte" tools:ignore="MissingTranslation">bytes</string>
+    <string name="u_kilobyte" tools:ignore="MissingTranslation">KB</string>
+    <string name="u_megabyte" tools:ignore="MissingTranslation">MB</string>
+    <string name="u_gigabyte" tools:ignore="MissingTranslation">GB</string>
+    <string name="u_terabyte" tools:ignore="MissingTranslation">TB</string>
+    <string name="u_petabyte" tools:ignore="MissingTranslation">PB</string>
+    <string name="u_exabyte" tools:ignore="MissingTranslation">EB</string>
 </resources>


### PR DESCRIPTION
**Implements Feature:** En and Ru locales cleanup
<br />

Summary of changes in this PR:

- Added `tools:ignore="MissingTranslation"` to more strings that not necessarily need to be translated

- Marked `app_name` untranslatable

- Fixed a few comments's position

- Reverted `%%` to `%` where necessary

<br />
@AVnetWS/admin-team
