### PR TITLE
Localization: Reformatted resource files and RU additions

### DIFF
--- a/app/src/main/res/values-fr/strings_download_service.xml
+++ b/app/src/main/res/values-fr/strings_download_service.xml
@@ -3,6 +3,7 @@
     <plurals name="download_completed">
         <item quantity="one" tools:ignore="ImpliedQuantity">Téléchargement terminé</item>
         <item quantity="other">%d téléchargements terminés</item>
+        <item quantity="many">%d téléchargements terminés</item>
     </plurals>
     <string name="download_complete">Téléchargement terminé</string>
     <string name="download_cancelled">Téléchargement annulé</string>
@@ -14,6 +15,7 @@
     <plurals name="add_to_queue">
         <item quantity="one">%1$d/%2$d élément ajouté à la file d\'attente</item>
         <item quantity="other">%1$d/%2$d éléments ajoutés à la file d\'attente</item>
+        <item quantity="many">%1$d/%2$d éléments ajoutés à la file d\'attente</item>
     </plurals>
     <string name="already_downloaded">Déjà téléchargé</string>
     <string name="already_queued">Déjà en file d\'attente</string>

--- a/app/src/main/res/values-it/array_preferences.xml
+++ b/app/src/main/res/values-it/array_preferences.xml
@@ -64,4 +64,5 @@
     <string name="pref_lock_timer_entries_1">Nessun ritardo</string>
     <string name="pref_lock_timer_entries_2">10 sec</string>
     <string name="pref_lock_timer_entries_3">30 sec (predefinito)</string>
+    <string name="pref_lock_timer_entries_5">2 min</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -827,6 +827,24 @@
     <string name="theme_light">Светлая</string>
     <string name="theme_deep_red">Тёмно-красная</string>
     <string name="theme_dark">Тёмная</string>
+    <!-- Book languages detected by the app -->
+    <string name="lang_en">английский</string>
+    <string name="lang_zh">китайский</string>
+    <string name="lang_ja">японский</string>
+    <string name="lang_ko">корейский</string>
+    <string name="lang_es">испанский</string>
+    <string name="lang_ru">русский</string>
+    <string name="lang_pt">португальский</string>
+    <string name="lang_th">тайский</string>
+    <string name="lang_fr">французский</string>
+    <string name="lang_vi">вьетнамский</string>
+    <string name="lang_it">итальянский</string>
+    <string name="lang_de">немецкий</string>
+    <string name="lang_pl">польский</string>
+    <string name="lang_id">индонезийский</string>
+    <string name="lang_hu">венгерский</string>
+    <string name="lang_tr">турецкий</string>
+    <string name="lang_cs">чешский</string>
     <!-- Misc -->
     <string name="select_file_manager">Выберите ваш файловый менеджер</string>
     <string name="default_permission">Стандартное разрешение</string>

--- a/app/src/main/res/values/array_plug_reactions.xml
+++ b/app/src/main/res/values/array_plug_reactions.xml
@@ -1,51 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <!-- DO NOT modify the way these arrays are set up - it is required for Weblate to work -->
-    <!-- see https://docs.weblate.org/en/latest/formats.html#android-string-resources -->
-
-    <string-array name="audio_reactions" translatable="false">
-        <item>@string/audio_plug1</item>
-        <item>@string/audio_plug2</item>
-        <item>@string/audio_plug3</item>
-        <item>@string/audio_plug4</item>
-        <item>@string/audio_plug5</item>
-        <item>@string/audio_plug6</item>
-        <item>@string/audio_plug7</item>
-    </string-array>
     <!-- Plugging in audio device reaction -->
     <string name="audio_plug1">yametee~~♡</string>
-    <!-- Plugging in audio device reaction -->
     <string name="audio_plug2">stop, that\'s… the wrong hole~</string>
-    <!-- Plugging in audio device reaction -->
     <string name="audio_plug3">ughhh~</string>
-    <!-- Plugging in audio device reaction -->
     <string name="audio_plug4">ewww ♡ ♡</string>
-    <!-- Plugging in audio device reaction -->
     <string name="audio_plug5">not here~~♡</string>
-    <!-- Plugging in audio device reaction -->
     <string name="audio_plug6">bad, bad boy~~</string>
-    <!-- Plugging in audio device reaction -->
     <string name="audio_plug7">too… tight…♡</string>
-    <!-- Plugging in audio device reaction -->
-    <string-array name="power_reactions" translatable="false">
-        <item>♡~</item>
-        <item>@string/power_plug1</item>
-        <item>@string/power_plug2</item>
-        <item>@string/power_plug3</item>
-        <item>@string/power_plug4</item>
-        <item>@string/power_plug5</item>
-        <item>@string/power_plug6</item>
-    </string-array>
     <!-- Plugging in power cord reaction -->
     <string name="power_plug1">I like it there~~</string>
-    <!-- Plugging in power cord reaction -->
     <string name="power_plug2">push it further~~~♡</string>
-    <!-- Plugging in power cord reaction -->
     <string name="power_plug3">ikuuuu~~</string>
-    <!-- Plugging in power cord reaction -->
     <string name="power_plug4">ahh ♡</string>
-    <!-- Plugging in power cord reaction -->
     <string name="power_plug5">ohhh~</string>
-    <!-- Plugging in power cord reaction -->
     <string name="power_plug6">give me more ♡</string>
 </resources>

--- a/app/src/main/res/values/array_preferences.xml
+++ b/app/src/main/res/values/array_preferences.xml
@@ -1,453 +1,100 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- DO NOT modify the way these arrays are set up - it is required for Weblate to work -->
-    <!-- see https://docs.weblate.org/en/latest/formats.html#android-string-resources -->
-    <string-array name="pref_library_display_entries" translatable="false">
-        <item>@string/pref_library_display_entries_1</item>
-        <item>@string/pref_library_display_entries_2</item>
-    </string-array>
-    <string-array name="pref_library_display_values" translatable="false">
-        <item>0</item>
-        <item>1</item>
-    </string-array>
     <!-- Choice for "Display type" setting -->
     <string name="pref_library_display_entries_1">List (default)</string>
-    <!-- Choice for "Display type" setting -->
     <string name="pref_library_display_entries_2">Grid</string>
-    <string-array name="pref_quantity_per_page_entries" translatable="false">
-        <item>20</item>
-        <item>40</item>
-        <item>60</item>
-        <item>80</item>
-        <item>100</item>
-    </string-array>
-    <string-array name="pref_quantity_per_page_entry_values" translatable="false">
-        <item>20</item>
-        <item>40</item>
-        <item>60</item>
-        <item>80</item>
-        <item>100</item>
-    </string-array>
-    <string-array name="pref_memory_alert_entries" translatable="false">
-        <item>@string/pref_memory_alert_entries_1</item>
-        <item>@string/pref_memory_alert_entries_2</item>
-        <item>@string/pref_memory_alert_entries_3</item>
-        <item>@string/pref_memory_alert_entries_4</item>
-    </string-array>
-    <string-array name="pref_memory_alert_values" translatable="false">
-        <item>110</item>
-        <item>90</item>
-        <item>95</item>
-        <item>98</item>
-    </string-array>
     <!-- Choice for "Alert on low memory" setting -->
     <string name="pref_memory_alert_entries_1">No alert</string>
-    <!-- Choice for "Alert on low memory" setting -->
     <string name="pref_memory_alert_entries_2" tools:ignore="StringFormatInvalid">on 90% full</string>
-    <!-- Choice for "Alert on low memory" setting -->
     <string name="pref_memory_alert_entries_3" tools:ignore="StringFormatInvalid">on 95% full</string>
-    <!-- Choice for "Alert on low memory" setting -->
     <string name="pref_memory_alert_entries_4" tools:ignore="StringFormatInvalid">on 98% full</string>
-    <string-array name="pref_browser_quick_dl_threshold_entries" translatable="false">
-        <item>@string/pref_browser_quick_dl_threshold_entries_1</item>
-        <item>@string/pref_browser_quick_dl_threshold_entries_2</item>
-        <item>@string/pref_browser_quick_dl_threshold_entries_3</item>
-        <item>@string/pref_browser_quick_dl_threshold_entries_4</item>
-        <item>@string/pref_browser_quick_dl_threshold_entries_5</item>
-    </string-array>
-    <string-array name="pref_browser_quick_dl_threshold_values" translatable="false">
-        <item>500</item>
-        <item>1000</item>
-        <item>1500</item>
-        <item>2000</item>
-        <item>3000</item>
-    </string-array>
     <!-- Choice for "Quick download long press threshold" setting -->
     <string name="pref_browser_quick_dl_threshold_entries_1">500 ms (default)</string>
-    <!-- Choice for "Quick download long press threshold" setting -->
     <string name="pref_browser_quick_dl_threshold_entries_2" tools:ignore="MissingTranslation">1 s</string>
-    <!-- Choice for "Quick download long press threshold" setting -->
     <string name="pref_browser_quick_dl_threshold_entries_3" tools:ignore="MissingTranslation">1.5 s</string>
-    <!-- Choice for "Quick download long press threshold" setting -->
     <string name="pref_browser_quick_dl_threshold_entries_4" tools:ignore="MissingTranslation">2 s</string>
-    <!-- Choice for "Quick download long press threshold" setting -->
     <string name="pref_browser_quick_dl_threshold_entries_5" tools:ignore="MissingTranslation">3 s</string>
-    <string-array name="pref_browser_dns_entries" translatable="false">
-        <item>@string/pref_browser_dns_entries_1</item>
-        <item>Cloudflare</item>
-        <item>Quad9</item>
-        <item>AdGuard</item>
-    </string-array>
-    <string-array name="pref_browser_dns_values" translatable="false">
-        <item>-1</item>
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-    </string-array>
     <!-- Choice for "DNS over HTTPS entries" setting -->
     <string name="pref_browser_dns_entries_1">None</string>
-    <string-array name="pref_queue_new_position_entries" translatable="false">
-        <item>@string/pref_queue_new_position_entries_1</item>
-        <item>@string/pref_queue_new_position_entries_2</item>
-        <item>@string/pref_queue_new_position_entries_3</item>
-    </string-array>
-    <string-array name="pref_queue_new_position_values" translatable="false">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-    </string-array>
     <!-- Choice for "New downloads position" setting -->
     <string name="pref_queue_new_position_entries_1">Top</string>
-    <!-- Choice for "New downloads position" setting -->
     <string name="pref_queue_new_position_entries_2">Bottom</string>
-    <!-- Choice for "New downloads position" setting -->
     <string name="pref_queue_new_position_entries_3">Ask every time</string>
-    <string-array name="pref_dl_size_wifi_threshold_entries" translatable="false">
-        <item>@string/pref_dl_size_wifi_threshold_entries_1</item>
-        <item>@string/pref_dl_size_wifi_threshold_entries_2</item>
-        <item>@string/pref_dl_size_wifi_threshold_entries_3</item>
-        <item>@string/pref_dl_size_wifi_threshold_entries_4</item>
-        <item>@string/pref_dl_size_wifi_threshold_entries_5</item>
-    </string-array>
-    <string-array name="pref_dl_size_wifi_threshold_values" translatable="false">
-        <item>999999</item>
-        <item>20</item>
-        <item>40</item>
-        <item>100</item>
-        <item>200</item>
-    </string-array>
     <!-- Choice for "Large downloads size threshold" setting -->
     <string name="pref_dl_size_wifi_threshold_entries_1">No size limit</string>
-    <!-- Choice for "Large downloads size threshold" setting -->
     <string name="pref_dl_size_wifi_threshold_entries_2" tools:ignore="MissingTranslation">20 MB</string>
-    <!-- Choice for "Large downloads size threshold" setting -->
     <string name="pref_dl_size_wifi_threshold_entries_3" tools:ignore="MissingTranslation">40 MB</string>
-    <!-- Choice for "Large downloads size threshold" setting -->
     <string name="pref_dl_size_wifi_threshold_entries_4" tools:ignore="MissingTranslation">100 MB</string>
-    <!-- Choice for "Large downloads size threshold" setting -->
     <string name="pref_dl_size_wifi_threshold_entries_5" tools:ignore="MissingTranslation">200 MB</string>
-    <string-array name="pref_dl_pages_wifi_threshold_entries" translatable="false">
-        <item>@string/pref_dl_pages_wifi_threshold_entries_1</item>
-        <item>@string/pref_dl_pages_wifi_threshold_entries_2</item>
-        <item>@string/pref_dl_pages_wifi_threshold_entries_3</item>
-        <item>@string/pref_dl_pages_wifi_threshold_entries_4</item>
-        <item>@string/pref_dl_pages_wifi_threshold_entries_5</item>
-    </string-array>
-    <string-array name="pref_dl_pages_wifi_threshold_values" translatable="false">
-        <item>999999</item>
-        <item>60</item>
-        <item>120</item>
-        <item>200</item>
-        <item>500</item>
-    </string-array>
     <!-- Choice for "Large downloads pages threshold" setting -->
     <string name="pref_dl_pages_wifi_threshold_entries_1">No page limit</string>
-    <!-- Choice for "Large downloads pages threshold" setting -->
     <string name="pref_dl_pages_wifi_threshold_entries_2">60 pages</string>
-    <!-- Choice for "Large downloads pages threshold" setting -->
     <string name="pref_dl_pages_wifi_threshold_entries_3">120 pages</string>
-    <!-- Choice for "Large downloads pages threshold" setting -->
     <string name="pref_dl_pages_wifi_threshold_entries_4">200 pages</string>
-    <!-- Choice for "Large downloads pages threshold" setting -->
     <string name="pref_dl_pages_wifi_threshold_entries_5">500 pages</string>
-    <string-array name="pref_dl_threads_quantity_entries" translatable="false">
-        <item>@string/pref_dl_threads_quantity_entries_1</item>
-        <item>@string/pref_dl_threads_quantity_entries_2</item>
-        <item>4</item>
-        <item>6</item>
-        <item>8</item>
-        <item>@string/pref_dl_threads_quantity_entries_6</item>
-    </string-array>
-    <string-array name="pref_dl_threads_quantity_values" translatable="false">
-        <item>0</item>
-        <item>2</item>
-        <item>4</item>
-        <item>6</item>
-        <item>8</item>
-        <item>10</item>
-    </string-array>
     <!-- Choice for "Number of parallel downloads" setting -->
     <string name="pref_dl_threads_quantity_entries_1">Auto (default)</string>
-    <!-- Choice for "Number of parallel downloads" setting -->
     <string name="pref_dl_threads_quantity_entries_2">2 (slow Internet)</string>
-    <!-- Choice for "Number of parallel downloads" setting -->
     <string name="pref_dl_threads_quantity_entries_6">10 (fast Internet; high-end phone)</string>
-    <string-array name="pref_folder_naming_content_entries" translatable="false">
-        <item>@string/pref_folder_naming_content_entries_1</item>
-        <item>@string/pref_folder_naming_content_entries_2</item>
-        <item>@string/pref_folder_naming_content_entries_3</item>
-        <item>@string/pref_folder_naming_content_entries_4</item>
-    </string-array>
-    <string-array name="pref_folder_naming_content_entry_values" translatable="false">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-    </string-array>
     <!-- Choice for "Book folder naming convention" setting -->
     <string name="pref_folder_naming_content_entries_1" tools:ignore="MissingTranslation">ID</string>
-    <!-- Choice for "Book folder naming convention" setting -->
     <string name="pref_folder_naming_content_entries_2">Title - ID</string>
-    <!-- Choice for "Book folder naming convention" setting -->
     <string name="pref_folder_naming_content_entries_3">Artist - Title - ID</string>
-    <!-- Choice for "Book folder naming convention" setting -->
     <string name="pref_folder_naming_content_entries_4">Title - Artist - ID</string>
-    <string-array name="pref_folder_trunc_content_entries" translatable="false">
-        <item>@string/pref_folder_trunc_content_entries_1</item>
-        <item>@string/pref_folder_trunc_content_entries_2</item>
-        <item>@string/pref_folder_trunc_content_entries_3</item>
-        <item>@string/pref_folder_trunc_content_entries_4</item>
-        <item>@string/pref_folder_trunc_content_entries_5</item>
-    </string-array>
-    <string-array name="pref_folder_trunc_content_entry_values" translatable="false">
-        <item>0</item>
-        <item>60</item>
-        <item>80</item>
-        <item>100</item>
-        <item>120</item>
-    </string-array>
     <!-- Choice for "Truncate folder name" setting -->
     <string name="pref_folder_trunc_content_entries_1">None</string>
-    <!-- Choice for "Truncate folder name" setting -->
     <string name="pref_folder_trunc_content_entries_2">60 characters</string>
-    <!-- Choice for "Truncate folder name" setting -->
     <string name="pref_folder_trunc_content_entries_3">80 characters</string>
-    <!-- Choice for "Truncate folder name" setting -->
     <string name="pref_folder_trunc_content_entries_4">100 characters</string>
-    <!-- Choice for "Truncate folder name" setting -->
     <string name="pref_folder_trunc_content_entries_5">120 characters</string>
-    <string-array name="pref_webview_initial_zoom_entries" translatable="false">
-        <item>0</item>
-        <item>20</item>
-        <item>50</item>
-        <item>100</item>
-    </string-array>
-    <string-array name="pref_webview_initial_zoom_values" translatable="false">
-        <item>0</item>
-        <item>20</item>
-        <item>50</item>
-        <item>100</item>
-    </string-array>
-    <string-array name="pref_viewer_dl_action_entries" translatable="false">
-        <item>@string/pref_viewer_dl_action_entries_1</item>
-        <item>@string/pref_viewer_dl_action_entries_2</item>
-    </string-array>
-    <string-array name="pref_viewer_dl_action_values" translatable="false">
-        <item>0</item>
-        <item>1</item>
-    </string-array>
     <!-- Choice for "Download action" setting -->
     <string name="pref_viewer_dl_action_entries_1">Download all pages</string>
-    <!-- Choice for "Download action" setting -->
     <string name="pref_viewer_dl_action_entries_2">Stream the pages when reading</string>
-    <string-array name="pref_attribute_list_order_entries" translatable="false">
-        <item>@string/pref_attribute_list_order_entries_1</item>
-        <item>@string/pref_attribute_list_order_entries_2</item>
-    </string-array>
-    <string-array name="pref_attribute_list_order_values" translatable="false">
-        <item>0</item>
-        <item>1</item>
-    </string-array>
     <!-- Choice for "Sort order of displayed metadata" setting -->
     <string name="pref_attribute_list_order_entries_1">Alphabetical</string>
-    <!-- Choice for "Sort order of displayed metadata" setting -->
     <string name="pref_attribute_list_order_entries_2">Item count (most used first)</string>
-    <string-array name="pref_color_theme_entries" translatable="false">
-        <item>@string/theme_light</item>
-        <item>@string/theme_deep_red</item>
-        <item>@string/theme_dark</item>
-    </string-array>
-    <string-array name="pref_color_theme_values" translatable="false">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-    </string-array>
-    <string-array name="pref_dl_retries_number_entries" translatable="false">
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-        <item>5</item>
-    </string-array>
-    <string-array name="pref_dl_retries_mem_limit_entries" translatable="false">
-        <item>90%</item>
-        <item>95%</item>
-        <item>98%</item>
-        <item>@string/pref_dl_retries_mem_limit_entries_4</item>
-    </string-array>
-    <string-array name="pref_dl_retries_mem_limit_values" translatable="false">
-        <item>90</item>
-        <item>95</item>
-        <item>98</item>
-        <item>100</item>
-    </string-array>
     <!-- Choice for "Mem usage threshold before aborting" setting -->
     <string name="pref_dl_retries_mem_limit_entries_4">None</string>
-    <string-array name="pref_dl_blocked_tags_behaviour_entries" translatable="false">
-        <item>@string/pref_dl_blocked_tags_behaviour_entries_1</item>
-        <item>@string/pref_dl_blocked_tags_behaviour_entries_2</item>
-    </string-array>
-    <string-array name="pref_dl_blocked_tags_behaviour_values" translatable="false">
-        <item>0</item>
-        <item>1</item>
-    </string-array>
     <!-- Choice for "Blocking behaviour" setting -->
     <string name="pref_dl_blocked_tags_behaviour_entries_1">Don\'t queue</string>
-    <!-- Choice for "Blocking behaviour" setting -->
     <string name="pref_dl_blocked_tags_behaviour_entries_2">Queue as download error</string>
-    <string-array name="pref_viewer_browse_mode_entries" translatable="false">
-        <item>@string/pref_viewer_browse_mode_entries_1</item>
-        <item>@string/pref_viewer_browse_mode_entries_2</item>
-        <item>@string/pref_viewer_browse_mode_entries_3</item>
-    </string-array>
-    <string-array name="pref_viewer_browse_mode_values" translatable="false">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-    </string-array>
     <!-- Choice for "Browse mode" setting -->
     <string name="pref_viewer_browse_mode_entries_1">Left to Right</string>
-    <!-- Choice for "Browse mode" setting -->
     <string name="pref_viewer_browse_mode_entries_2">Right to Left</string>
-    <!-- Choice for "Browse mode" setting -->
     <string name="pref_viewer_browse_mode_entries_3">Top to Bottom</string>
-    <string-array name="pref_viewer_separating_bars_entries" translatable="false">
-        <item>@string/pref_viewer_separating_bars_entries_1</item>
-        <item>@string/pref_viewer_separating_bars_entries_2</item>
-        <item>@string/pref_viewer_separating_bars_entries_3</item>
-        <item>@string/pref_viewer_separating_bars_entries_4</item>
-    </string-array>
-    <string-array name="pref_viewer_separating_bars_values" translatable="false">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-    </string-array>
     <!-- Choice for "Separating bars in vertical mode" setting -->
     <string name="pref_viewer_separating_bars_entries_1">Off (default)</string>
-    <!-- Choice for "Separating bars in vertical mode" setting -->
     <string name="pref_viewer_separating_bars_entries_2">Small</string>
-    <!-- Choice for "Separating bars in vertical mode" setting -->
     <string name="pref_viewer_separating_bars_entries_3">Medium</string>
-    <!-- Choice for "Separating bars in vertical mode" setting -->
     <string name="pref_viewer_separating_bars_entries_4">Large</string>
-    <string-array name="pref_viewer_read_threshold_entries" translatable="false">
-        <item>@string/pref_viewer_read_threshold_entries_1</item>
-        <item>@string/pref_viewer_read_threshold_entries_2</item>
-        <item>@string/pref_viewer_read_threshold_entries_3</item>
-        <item>@string/pref_viewer_read_threshold_entries_4</item>
-    </string-array>
-    <string-array name="pref_viewer_read_threshold_values" translatable="false">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-    </string-array>
     <!-- Choice for "Mark book as read after N pages" setting -->
     <string name="pref_viewer_read_threshold_entries_1">1 page (default)</string>
-    <!-- Choice for "Mark book as read after N pages" setting -->
     <string name="pref_viewer_read_threshold_entries_2">2 pages</string>
-    <!-- Choice for "Mark book as read after N pages" setting -->
     <string name="pref_viewer_read_threshold_entries_3">5 pages</string>
-    <!-- Choice for "Mark book as read after N pages" setting -->
     <string name="pref_viewer_read_threshold_entries_4">All pages</string>
-    <string-array name="pref_viewer_slideshow_delay_entries" translatable="false">
-        <item>@string/pref_viewer_slideshow_delay_entries_1</item>
-        <item>@string/pref_viewer_slideshow_delay_entries_2</item>
-        <item>@string/pref_viewer_slideshow_delay_entries_3</item>
-        <item>@string/pref_viewer_slideshow_delay_entries_4</item>
-        <item>@string/pref_viewer_slideshow_delay_entries_5</item>
-        <item>@string/pref_viewer_slideshow_delay_entries_6</item>
-    </string-array>
-    <string-array name="pref_viewer_slideshow_delay_values" translatable="false">
-        <item>5</item>
-        <item>4</item>
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-    </string-array>
     <!-- Choice for "Slideshow delay" setting -->
     <string name="pref_viewer_slideshow_delay_entries_1" tools:ignore="MissingTranslation">500 ms</string>
-    <!-- Choice for "Slideshow delay" setting -->
     <string name="pref_viewer_slideshow_delay_entries_2" tools:ignore="MissingTranslation">1 s</string>
-    <!-- Choice for "Slideshow delay" setting -->
     <string name="pref_viewer_slideshow_delay_entries_3">2 s (default)</string>
-    <!-- Choice for "Slideshow delay" setting -->
     <string name="pref_viewer_slideshow_delay_entries_4" tools:ignore="MissingTranslation">4 s</string>
-    <!-- Choice for "Slideshow delay" setting -->
     <string name="pref_viewer_slideshow_delay_entries_5" tools:ignore="MissingTranslation">8 s</string>
-    <!-- Choice for "Slideshow delay" setting -->
     <string name="pref_viewer_slideshow_delay_entries_6" tools:ignore="MissingTranslation">16 s</string>
-    <string-array name="pref_viewer_display_mode_entries" translatable="false">
-        <item>@string/pref_viewer_display_mode_entries_1</item>
-        <item>@string/pref_viewer_display_mode_entries_2</item>
-        <item>@string/pref_viewer_display_mode_entries_3</item>
-    </string-array>
-    <string-array name="pref_viewer_display_mode_values" translatable="false">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-    </string-array>
     <!-- Choice for "Display mode" setting -->
     <string name="pref_viewer_display_mode_entries_1">Fit to screen (default)</string>
-    <!-- Choice for "Display mode" setting -->
     <string name="pref_viewer_display_mode_entries_2">Fill screen (proportionate)</string>
-    <!-- Choice for "Display mode" setting -->
     <string name="pref_viewer_display_mode_entries_3">Fill screen (stretch)</string>
-    <string-array name="pref_viewer_rendering_entries" translatable="false">
-        <item>@string/pref_viewer_rendering_entries_1</item>
-        <item>@string/pref_viewer_rendering_entries_2</item>
-    </string-array>
-    <string-array name="pref_viewer_rendering_values" translatable="false">
-        <item>0</item>
-        <item>1</item>
-    </string-array>
     <!-- Choice for "Rendering mode" setting -->
     <string name="pref_viewer_rendering_entries_1">Sharp rendering (default)</string>
-    <!-- Choice for "Rendering mode" setting -->
     <string name="pref_viewer_rendering_entries_2">Smooth rendering</string>
-    <string-array name="pref_viewer_cap_tap_zoom_entries" translatable="false">
-        <item>@string/pref_viewer_cap_tap_zoom_entries_1</item>
-        <item>@string/pref_viewer_cap_tap_zoom_entries_2</item>
-        <item>@string/pref_viewer_cap_tap_zoom_entries_3</item>
-        <item>@string/pref_viewer_cap_tap_zoom_entries_4</item>
-    </string-array>
-    <string-array name="pref_viewer_cap_tap_zoom_values" translatable="false">
-        <item>0</item>
-        <item>2</item>
-        <item>4</item>
-        <item>6</item>
-    </string-array>
     <!-- Choice for "Cap double & long tap zoom" setting -->
     <string name="pref_viewer_cap_tap_zoom_entries_1">No capping</string>
-    <!-- Choice for "Cap double & long tap zoom" setting -->
     <string name="pref_viewer_cap_tap_zoom_entries_2" tools:ignore="MissingTranslation">2x</string>
-    <!-- Choice for "Cap double & long tap zoom" setting -->
     <string name="pref_viewer_cap_tap_zoom_entries_3" tools:ignore="MissingTranslation">4x</string>
-    <!-- Choice for "Cap double & long tap zoom" setting -->
     <string name="pref_viewer_cap_tap_zoom_entries_4" tools:ignore="MissingTranslation">6x</string>
-    <string-array name="pref_viewer_gallery_columns_values" translatable="false">
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-        <item>5</item>
-    </string-array>
-    <string-array name="pref_lock_timer_entries" translatable="false">
-        <item>@string/pref_lock_timer_entries_1</item>
-        <item>@string/pref_lock_timer_entries_2</item>
-        <item>@string/pref_lock_timer_entries_3</item>
-        <item>@string/pref_lock_timer_entries_4</item>
-        <item>@string/pref_lock_timer_entries_5</item>
-    </string-array>
     <!-- Choice for "Lock timer" setting -->
     <string name="pref_lock_timer_entries_1">No delay</string>
-    <!-- Choice for "Lock timer" setting -->
     <string name="pref_lock_timer_entries_2" tools:ignore="MissingTranslation">10 s</string>
-    <!-- Choice for "Lock timer" setting -->
     <string name="pref_lock_timer_entries_3">30 s (default)</string>
-    <!-- Choice for "Lock timer" setting -->
     <string name="pref_lock_timer_entries_4" tools:ignore="MissingTranslation">1 min</string>
-    <!-- Choice for "Lock timer" setting -->
     <string name="pref_lock_timer_entries_5">2 mins</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,0 +1,429 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" xmlns:x="urn:oasis:names:tc:xliff:document:1.2" translatable="false" tools:ignore="MissingTranslation">
+    <!-- Array: Plug Reactions -->
+    <string-array name="audio_reactions" translatable="false">
+        <item>@string/audio_plug1</item>
+        <item>@string/audio_plug2</item>
+        <item>@string/audio_plug3</item>
+        <item>@string/audio_plug4</item>
+        <item>@string/audio_plug5</item>
+        <item>@string/audio_plug6</item>
+        <item>@string/audio_plug7</item>
+    </string-array>
+    <string-array name="power_reactions" translatable="false">
+        <item>♡~</item>
+        <item>@string/power_plug1</item>
+        <item>@string/power_plug2</item>
+        <item>@string/power_plug3</item>
+        <item>@string/power_plug4</item>
+        <item>@string/power_plug5</item>
+        <item>@string/power_plug6</item>
+    </string-array>
+
+    <!-- Array: Preferences -->
+    <string-array name="pref_library_display_entries" translatable="false">
+        <item>@string/pref_library_display_entries_1</item>
+        <item>@string/pref_library_display_entries_2</item>
+    </string-array>
+    <string-array name="pref_library_display_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+    <string-array name="pref_quantity_per_page_entries" translatable="false">
+        <item>20</item>
+        <item>40</item>
+        <item>60</item>
+        <item>80</item>
+        <item>100</item>
+    </string-array>
+    <string-array name="pref_quantity_per_page_entry_values" translatable="false">
+        <item>20</item>
+        <item>40</item>
+        <item>60</item>
+        <item>80</item>
+        <item>100</item>
+    </string-array>
+    <string-array name="pref_memory_alert_entries" translatable="false">
+        <item>@string/pref_memory_alert_entries_1</item>
+        <item>@string/pref_memory_alert_entries_2</item>
+        <item>@string/pref_memory_alert_entries_3</item>
+        <item>@string/pref_memory_alert_entries_4</item>
+    </string-array>
+    <string-array name="pref_memory_alert_values" translatable="false">
+        <item>110</item>
+        <item>90</item>
+        <item>95</item>
+        <item>98</item>
+    </string-array>
+    <string-array name="pref_browser_quick_dl_threshold_entries" translatable="false">
+        <item>@string/pref_browser_quick_dl_threshold_entries_1</item>
+        <item>@string/pref_browser_quick_dl_threshold_entries_2</item>
+        <item>@string/pref_browser_quick_dl_threshold_entries_3</item>
+        <item>@string/pref_browser_quick_dl_threshold_entries_4</item>
+        <item>@string/pref_browser_quick_dl_threshold_entries_5</item>
+    </string-array>
+    <string-array name="pref_browser_quick_dl_threshold_values" translatable="false">
+        <item>500</item>
+        <item>1000</item>
+        <item>1500</item>
+        <item>2000</item>
+        <item>3000</item>
+    </string-array>
+    <string-array name="pref_browser_dns_entries" translatable="false">
+        <item>@string/pref_browser_dns_entries_1</item>
+        <item>Cloudflare</item>
+        <item>Quad9</item>
+        <item>AdGuard</item>
+    </string-array>
+    <string-array name="pref_browser_dns_values" translatable="false">
+        <item>-1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+    <string-array name="pref_queue_new_position_entries" translatable="false">
+        <item>@string/pref_queue_new_position_entries_1</item>
+        <item>@string/pref_queue_new_position_entries_2</item>
+        <item>@string/pref_queue_new_position_entries_3</item>
+    </string-array>
+    <string-array name="pref_queue_new_position_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+    <string-array name="pref_dl_size_wifi_threshold_entries" translatable="false">
+        <item>@string/pref_dl_size_wifi_threshold_entries_1</item>
+        <item>@string/pref_dl_size_wifi_threshold_entries_2</item>
+        <item>@string/pref_dl_size_wifi_threshold_entries_3</item>
+        <item>@string/pref_dl_size_wifi_threshold_entries_4</item>
+        <item>@string/pref_dl_size_wifi_threshold_entries_5</item>
+    </string-array>
+    <string-array name="pref_dl_size_wifi_threshold_values" translatable="false">
+        <item>999999</item>
+        <item>20</item>
+        <item>40</item>
+        <item>100</item>
+        <item>200</item>
+    </string-array>
+    <string-array name="pref_dl_pages_wifi_threshold_entries" translatable="false">
+        <item>@string/pref_dl_pages_wifi_threshold_entries_1</item>
+        <item>@string/pref_dl_pages_wifi_threshold_entries_2</item>
+        <item>@string/pref_dl_pages_wifi_threshold_entries_3</item>
+        <item>@string/pref_dl_pages_wifi_threshold_entries_4</item>
+        <item>@string/pref_dl_pages_wifi_threshold_entries_5</item>
+    </string-array>
+    <string-array name="pref_dl_pages_wifi_threshold_values" translatable="false">
+        <item>999999</item>
+        <item>60</item>
+        <item>120</item>
+        <item>200</item>
+        <item>500</item>
+    </string-array>
+    <string-array name="pref_dl_threads_quantity_entries" translatable="false">
+        <item>@string/pref_dl_threads_quantity_entries_1</item>
+        <item>@string/pref_dl_threads_quantity_entries_2</item>
+        <item>4</item>
+        <item>6</item>
+        <item>8</item>
+        <item>@string/pref_dl_threads_quantity_entries_6</item>
+    </string-array>
+    <string-array name="pref_dl_threads_quantity_values" translatable="false">
+        <item>0</item>
+        <item>2</item>
+        <item>4</item>
+        <item>6</item>
+        <item>8</item>
+        <item>10</item>
+    </string-array>
+    <string-array name="pref_folder_naming_content_entries" translatable="false">
+        <item>@string/pref_folder_naming_content_entries_1</item>
+        <item>@string/pref_folder_naming_content_entries_2</item>
+        <item>@string/pref_folder_naming_content_entries_3</item>
+        <item>@string/pref_folder_naming_content_entries_4</item>
+    </string-array>
+    <string-array name="pref_folder_naming_content_entry_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
+    <string-array name="pref_folder_trunc_content_entries" translatable="false">
+        <item>@string/pref_folder_trunc_content_entries_1</item>
+        <item>@string/pref_folder_trunc_content_entries_2</item>
+        <item>@string/pref_folder_trunc_content_entries_3</item>
+        <item>@string/pref_folder_trunc_content_entries_4</item>
+        <item>@string/pref_folder_trunc_content_entries_5</item>
+    </string-array>
+    <string-array name="pref_folder_trunc_content_entry_values" translatable="false">
+        <item>0</item>
+        <item>60</item>
+        <item>80</item>
+        <item>100</item>
+        <item>120</item>
+    </string-array>
+    <string-array name="pref_webview_initial_zoom_entries" translatable="false">
+        <item>0</item>
+        <item>20</item>
+        <item>50</item>
+        <item>100</item>
+    </string-array>
+    <string-array name="pref_webview_initial_zoom_values" translatable="false">
+        <item>0</item>
+        <item>20</item>
+        <item>50</item>
+        <item>100</item>
+    </string-array>
+    <string-array name="pref_viewer_dl_action_entries" translatable="false">
+        <item>@string/pref_viewer_dl_action_entries_1</item>
+        <item>@string/pref_viewer_dl_action_entries_2</item>
+    </string-array>
+    <string-array name="pref_viewer_dl_action_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+    <string-array name="pref_attribute_list_order_entries" translatable="false">
+        <item>@string/pref_attribute_list_order_entries_1</item>
+        <item>@string/pref_attribute_list_order_entries_2</item>
+    </string-array>
+    <string-array name="pref_attribute_list_order_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+    <string-array name="pref_color_theme_entries" translatable="false">
+        <item>@string/theme_light</item>
+        <item>@string/theme_deep_red</item>
+        <item>@string/theme_dark</item>
+    </string-array>
+    <string-array name="pref_color_theme_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+    <string-array name="pref_dl_retries_number_entries" translatable="false">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+    </string-array>
+    <string-array name="pref_dl_retries_mem_limit_entries" translatable="false">
+        <item>90%</item>
+        <item>95%</item>
+        <item>98%</item>
+        <item>@string/pref_dl_retries_mem_limit_entries_4</item>
+    </string-array>
+    <string-array name="pref_dl_retries_mem_limit_values" translatable="false">
+        <item>90</item>
+        <item>95</item>
+        <item>98</item>
+        <item>100</item>
+    </string-array>
+    <string-array name="pref_dl_blocked_tags_behaviour_entries" translatable="false">
+        <item>@string/pref_dl_blocked_tags_behaviour_entries_1</item>
+        <item>@string/pref_dl_blocked_tags_behaviour_entries_2</item>
+    </string-array>
+    <string-array name="pref_dl_blocked_tags_behaviour_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+    <string-array name="pref_viewer_browse_mode_entries" translatable="false">
+        <item>@string/pref_viewer_browse_mode_entries_1</item>
+        <item>@string/pref_viewer_browse_mode_entries_2</item>
+        <item>@string/pref_viewer_browse_mode_entries_3</item>
+    </string-array>
+    <string-array name="pref_viewer_browse_mode_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+    <string-array name="pref_viewer_separating_bars_entries" translatable="false">
+        <item>@string/pref_viewer_separating_bars_entries_1</item>
+        <item>@string/pref_viewer_separating_bars_entries_2</item>
+        <item>@string/pref_viewer_separating_bars_entries_3</item>
+        <item>@string/pref_viewer_separating_bars_entries_4</item>
+    </string-array>
+    <string-array name="pref_viewer_separating_bars_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
+    <string-array name="pref_viewer_read_threshold_entries" translatable="false">
+        <item>@string/pref_viewer_read_threshold_entries_1</item>
+        <item>@string/pref_viewer_read_threshold_entries_2</item>
+        <item>@string/pref_viewer_read_threshold_entries_3</item>
+        <item>@string/pref_viewer_read_threshold_entries_4</item>
+    </string-array>
+    <string-array name="pref_viewer_read_threshold_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
+    <string-array name="pref_viewer_slideshow_delay_entries" translatable="false">
+        <item>@string/pref_viewer_slideshow_delay_entries_1</item>
+        <item>@string/pref_viewer_slideshow_delay_entries_2</item>
+        <item>@string/pref_viewer_slideshow_delay_entries_3</item>
+        <item>@string/pref_viewer_slideshow_delay_entries_4</item>
+        <item>@string/pref_viewer_slideshow_delay_entries_5</item>
+        <item>@string/pref_viewer_slideshow_delay_entries_6</item>
+    </string-array>
+    <string-array name="pref_viewer_slideshow_delay_values" translatable="false">
+        <item>5</item>
+        <item>4</item>
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
+    <string-array name="pref_viewer_display_mode_entries" translatable="false">
+        <item>@string/pref_viewer_display_mode_entries_1</item>
+        <item>@string/pref_viewer_display_mode_entries_2</item>
+        <item>@string/pref_viewer_display_mode_entries_3</item>
+    </string-array>
+    <string-array name="pref_viewer_display_mode_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+    <string-array name="pref_viewer_rendering_entries" translatable="false">
+        <item>@string/pref_viewer_rendering_entries_1</item>
+        <item>@string/pref_viewer_rendering_entries_2</item>
+    </string-array>
+    <string-array name="pref_viewer_rendering_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+    <string-array name="pref_viewer_cap_tap_zoom_entries" translatable="false">
+        <item>@string/pref_viewer_cap_tap_zoom_entries_1</item>
+        <item>@string/pref_viewer_cap_tap_zoom_entries_2</item>
+        <item>@string/pref_viewer_cap_tap_zoom_entries_3</item>
+        <item>@string/pref_viewer_cap_tap_zoom_entries_4</item>
+    </string-array>
+    <string-array name="pref_viewer_cap_tap_zoom_values" translatable="false">
+        <item>0</item>
+        <item>2</item>
+        <item>4</item>
+        <item>6</item>
+    </string-array>
+    <string-array name="pref_viewer_gallery_columns_values" translatable="false">
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+    </string-array>
+    <string-array name="pref_lock_timer_entries" translatable="false">
+        <item>@string/pref_lock_timer_entries_1</item>
+        <item>@string/pref_lock_timer_entries_2</item>
+        <item>@string/pref_lock_timer_entries_3</item>
+        <item>@string/pref_lock_timer_entries_4</item>
+        <item>@string/pref_lock_timer_entries_5</item>
+    </string-array>
+
+    <!-- Strings: Main: Generic Usage -->
+    <string name="app_name" translatable="false">Hentoid</string>
+    <string name="app_id" translatable="false">me.devsaki.hentoid</string>
+    <string name="error" translatable="false">Error</string>
+    <string name="empty" translatable="false"/>
+    <!-- Strings: Main: TextViews -->
+    <string name="work_untitled" translatable="false">[No data]</string>
+    <!-- Strings: Main: Export metadata -->
+    <string name="export_faq_url" translatable="false">https://github.com/avluis/Hentoid/wiki/FAQ#Lib-2</string>
+    <!-- Strings: Main: Import Activity -->
+    <!-- for logging only -->
+    <string name="enabled" translatable="false">ENABLED</string>
+    <string name="disabled" translatable="false">DISABLED</string>
+    <!-- Strings: Main: Logs -->
+    <string name="error_log_header" translatable="false">Error log for <x:g id="title">%1$s</x:g> [<x:g id="site_id">%2$s</x:g>@<x:g id="site_name">%3$s</x:g>]: <x:g id="error_count" example="2">%4$d</x:g> errors</string>
+    <string name="error_log_header_queue" translatable="false">Error log for queue</string>
+    <!-- Strings: Main: Library fragment -->
+    <string name="book_title" translatable="false">This is a rather long title, just because we need it to be.</string>
+    <string name="book_series" translatable="false">Series: Name</string>
+    <string name="book_artist" translatable="false">Artist: In this book there are so many artists crammed in one place that one display line definitely can\'t contain them all</string>
+    <string name="book_pages_queue" translatable="false">Pages: 1234; estimated 125 MB</string>
+    <string name="book_pages_library" translatable="false">1234 pages / 1125 MB</string>
+    <string name="book_pages_library2" translatable="false">1234 pages / 30 chapters / 1125 MB [Merged]</string>
+    <string name="book_tags" translatable="false">tag1, tag2, tag3, etc.</string>
+    <!-- Strings: Main: About Activity -->
+    <string name="about_github" translatable="false"><u>GitHub</u></string>
+    <string name="about_discord" translatable="false"><u>Discord</u></string>
+    <string name="about_reddit" translatable="false"><u>Reddit</u></string>
+    <!-- Strings: Main: Duplicate detector -->
+    <string name="duplicate_total_score" translatable="false">%.0f%%</string>
+
+    <!-- Strings: Settings -->
+    <string name="pref_generic_summary" translatable="false">%s</string>
+    <!-- Strings: Settings: Interface -->
+    <string name="pref_library_display_default" translatable="false">0</string>
+    <string name="pref_endless_scroll_default" translatable="false">true</string>
+    <string name="pref_quantity_per_page_default" translatable="false">20</string>
+    <string name="pref_attributes_list_order_default" translatable="false">1</string>
+    <string name="pref_attributes_list_order_summary" translatable="false">%s</string>
+    <string name="pref_attributes_list_count_default" translatable="false">true</string>
+    <string name="pref_color_theme_default" translatable="false">0</string>
+    <!-- Strings: Settings: Storage -->
+    <string name="pref_import_queue_empty_default" translatable="false">false</string>
+    <string name="pref_folder_naming_content_default" translatable="false">2</string>
+    <string name="pref_folder_trunc_default" translatable="false">100</string>
+    <string name="pref_memory_alert_default" translatable="false">110</string>
+    <string name="pref_external_library_delete_default" translatable="false">false</string>
+    <!-- Strings: Settings: Browser -->
+    <string name="pref_browser_resume_last_default" translatable="false">false</string>
+    <string name="pref_browser_dl_action_default" translatable="false">0</string>
+    <string name="pref_browser_quick_dl_default" translatable="false">true</string>
+    <string name="pref_browser_nhentai_invisible_blacklist_default" translatable="false">false</string>
+    <string name="pref_browser_quick_dl_threshold_default" translatable="false">500</string>
+    <string name="pref_browser_augmented_default" translatable="false">true</string>
+    <string name="pref_browser_duplicate_ask_default" translatable="false">true</string>
+    <string name="pref_browser_duplicate_try_pages_default" translatable="false">true</string>
+    <string name="pref_browser_mark_downloaded_default" translatable="false">false</string>
+    <string name="pref_browser_override_overview_default" translatable="false">false</string>
+    <string name="pref_browser_initial_zoom_default" translatable="false">20</string>
+    <string name="pref_browser_dns_default" translatable="false">-1</string>
+    <!-- Strings: Settings: Downloader -->
+    <string name="pref_queue_autostart_default" translatable="false">true</string>
+    <string name="pref_queue_wifi_only_default" translatable="false">false</string>
+    <string name="pref_queue_new_position_default" translatable="false">1</string>
+    <string name="pref_dl_size_wifi_default" translatable="false">false</string>
+    <string name="pref_dl_size_wifi_threshold_default" translatable="false">40</string>
+    <string name="pref_dl_pages_wifi_threshold_default" translatable="false">999999</string>
+    <string name="pref_dl_retries_active_default" translatable="false">false</string>
+    <string name="pref_dl_retries_number_summary" translatable="false">%s</string>
+    <string name="pref_dl_retries_number_default" translatable="false">3</string>
+    <string name="pref_dl_retries_mem_limit_summary" translatable="false">%s</string>
+    <string name="pref_dl_retries_mem_limit_default" translatable="false">100</string>
+    <string name="pref_dl_blocked_tags_behaviour_default" translatable="false">0</string>
+    <string name="pref_dl_hitomi" translatable="false">Hitomi.la</string>
+    <string name="pref_dl_hitomi_webp_default" translatable="false">true</string>
+    <string name="pref_dl_threads_quantity_default" translatable="false">0</string>
+    <!-- Strings: Settings: Privacy -->
+    <string name="pref_app_preview_default" translatable="false">false</string>
+    <string name="pref_analytics_preference_default" translatable="false">true</string>
+    <!-- Strings: Settings: Updates -->
+    <string name="pref_check_updates_default" translatable="false">true</string>
+    <!-- Strings: Settings: Viewer -->
+    <string name="pref_viewer_browse_mode_default" translatable="false">0</string>
+    <bool name="pref_viewer_page_turn_swipe_default" translatable="false">true</bool>
+    <bool name="pref_viewer_page_turn_tap_default" translatable="false">true</bool>
+    <bool name="pref_viewer_page_turn_tap_2x_default" translatable="false">false</bool>
+    <bool name="pref_viewer_page_turn_volume_default" translatable="false">true</bool>
+    <bool name="pref_viewer_page_turn_keyboard_default" translatable="false">true</bool>
+    <bool name="pref_viewer_swipe_to_fling_default" translatable="false">false</bool>
+    <bool name="pref_viewer_invert_volume_default" translatable="false">false</bool>
+    <bool name="pref_viewer_zoom_holding_default" translatable="false">false</bool>
+    <string name="pref_viewer_cap_tap_zoom_default" translatable="false">0</string>
+    <bool name="pref_viewer_keep_screen_on_default" translatable="false">true</bool>
+    <bool name="pref_viewer_display_pagenum_default" translatable="false">false</bool>
+    <bool name="pref_viewer_tap_transitions_default" translatable="false">true</bool>
+    <bool name="pref_viewer_zoom_transitions_default" translatable="false">true</bool>
+    <string name="pref_viewer_separating_bars_default" translatable="false">0</string>
+    <string name="pref_viewer_display_mode_default" translatable="false">0</string>
+    <string name="pref_viewer_rendering_default" translatable="false">0</string>
+    <bool name="pref_viewer_auto_rotate_default" translatable="false">false</bool>
+    <string name="pref_viewer_gallery_columns_default" translatable="false">4</string>
+    <bool name="pref_viewer_resume_last_left_default" translatable="false">true</bool>
+    <bool name="pref_viewer_open_gallery_default" translatable="false">false</bool>
+    <bool name="pref_viewer_continuous_default" translatable="false">false</bool>
+    <string name="pref_viewer_read_threshold_default" translatable="false">0</string>
+    <string name="pref_viewer_slideshow_delay_default" translatable="false">0</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" xmlns:x="urn:oasis:names:tc:xliff:document:1.2">
     <!-- Generic usage -->
-    <string name="app_name" translatable="false">Hentoid</string>
-    <string name="app_id" translatable="false">me.devsaki.hentoid</string>
     <string name="app_intro">Welcome</string>
     <!-- because Android default "OK" value for "yes" key is nonsense -->
     <string name="yes">Yes</string>
@@ -37,9 +35,8 @@
     <string name="menu_completed_single">Completed</string>
     <string name="service_running">Service is already running</string>
     <string name="open_folder">Open folder</string>
-    <string name="error" translatable="false">Error</string>
     <string name="_default">default</string>
-    <string name="empty" translatable="false"/>
+
     <!-- Activities -->
     <string name="title_activity_api29_migration">API 29 migration</string>
     <string name="title_activity_downloads">Library</string>
@@ -48,6 +45,7 @@
     <string name="title_activity_about">About</string>
     <string name="title_activity_app_lock">App Lock</string>
     <string name="title_activity_search">Advanced Search</string>
+
     <!-- API29 migration / library refresh screen -->
     <string name="api29_migration_title">Hentoid v12\nFile management update</string>
     <string name="api29_migration_subtitle">Hentoid is updating your collection.\nIt may require a few minutes.</string>
@@ -62,6 +60,7 @@
     <string name="api29_migration_step4_init">Importing queue…</string>
     <string name="api29_migration_select_folder">Please select an existing Hentoid folder. Its location is displayed on screen.</string>
     <string name="api29_migration_allow_write">Please allow write permission</string>
+
     <!-- Library screen toolbar -->
     <string name="menu_search">Search</string>
     <string name="menu_fav">Toggle favourite filter</string>
@@ -96,6 +95,7 @@
     <string name="low_memory">Your device is low on memory!</string>
     <string name="fix_permissions">Fix</string>
     <string name="view_queue">View queue</string>
+
     <!-- Queue / Downloader -->
     <string name="downloader_title">Downloader</string>
     <string name="queue_queue_tab">In progress</string>
@@ -164,8 +164,8 @@
     <string name="download_notif_speed" tools:ignore="MissingTranslation"><x:g id="size_dled" example="3.88">%1$d</x:g><x:g id="formatted_estimated_total" example="/14.56">%2$s</x:g> MB @ <x:g id="speed_kbps" example="102.4">%3$d</x:g> KBps</string>
     <string name="download_notif_failed">Download failed</string>
     <string name="download_notif_failed_details">Cannot download <x:g id="book_name" example="Cool H-Manga">%1$s</x:g>: unable to create folder <x:g id="path" example="/storage/emulated/0/Hentoid/nhentai/coolhmanga">%2$s</x:g>. Please check your Hentoid folder and retry downloading using the \'!\' button.</string>
+
     <!-- TextViews -->
-    <string name="work_untitled" translatable="false">[No data]</string>
     <string name="work_series">Series: <x:g id="series" example="original">%s</x:g></string>
     <string name="work_artist">Artist: <x:g id="artist" example="hayao miyazaki">%s</x:g></string>
     <plurals name="work_pages_missing">
@@ -190,10 +190,9 @@
     <string name="errortype_wifi">Book skipped because of Wi-Fi download size limitations</string>
     <string name="errortype_blocked">Book contains a blocked tag</string>
     <string name="errortype_undefined">Undefined</string>
+
     <!-- Refresh library -->
-    <!-- Menu item -->
     <string name="refresh_title">Refresh library</string>
-    <!-- Menu item description -->
     <string name="refresh_caption">Automatically refresh library data by rescanning files and folders.</string>
     <string name="refresh_options">Cleanup options</string>
     <string name="refresh_location_internal">Hentoid library</string>
@@ -204,6 +203,7 @@
     <string name="refresh_options_remove_2">No image has been downloaded</string>
     <string name="refresh_options_remove_3">JSON file is unreadable (not recommended)</string>
     <string name="refresh_options_remove_or">or</string>
+
     <!-- Delete all except favs -->
     <string name="delete_title">Delete all except favourites</string>
     <string name="generic_progress" tools:ignore="MissingTranslation"><x:g id="number" example="7">%1$d</x:g> / <x:g id="total" example="42">%2$d</x:g> <x:g id="type" example="books">%3$s</x:g></string>
@@ -215,6 +215,7 @@
         <item quantity="one"><x:g id="number" example="1">%1$d</x:g> / <x:g id="total" example="42">%2$d</x:g> group</item>
         <item quantity="other"><x:g id="number" example="2">%1$d</x:g> / <x:g id="total" example="42">%2$d</x:g> groups</item>
     </plurals>
+
     <!-- Import metadata -->
     <string name="import_title">Import metadata</string>
     <string name="import_mode_add">Add imported items</string>
@@ -248,6 +249,7 @@
         <item quantity="other"><x:g id="number" example="2">%d</x:g> bookmarks imported successfully</item>
     </plurals>
     <string name="dialog_prompt">Choose a Folder</string>
+
     <!-- Export metadata -->
     <string name="export_title">Export metadata</string>
     <plurals name="export_file_library">
@@ -266,10 +268,10 @@
     </plurals>
     <string name="export_warning1">Exporting metadata is meant to create a list of your books in JSON format.\nIt is not meant for moving your collection to your PC or your SD card.\nTap here to learn how to do that.</string>
     <string name="export_warning2">Books are exported without images.\nYou will have to download them again upon restore if the images folder is not present.</string>
-    <string name="export_faq_url" translatable="false">https://github.com/avluis/Hentoid/wiki/FAQ#Lib-2</string>
     <string name="export_run">RUN EXPORT</string>
     <string name="import_settings_title">Import settings</string>
     <string name="import_settings_success">Imported</string>
+
     <!-- Import Activity -->
     <string name="open_app_settings">Open App Settings</string>
     <string name="permissioncomplaint_snackbar">You must grant permissions before you can continue</string>
@@ -299,10 +301,7 @@
         <item quantity="one"><x:g id="number" example="1">%s</x:g> failed</item>
         <item quantity="other"><x:g id="number" example="2">%s</x:g> failed</item>
     </plurals>
-    <!-- for logging only -->
-    <string name="enabled" translatable="false">ENABLED</string>
-    <!-- for logging only -->
-    <string name="disabled" translatable="false">DISABLED</string>
+
     <!-- Memory usage -->
     <string name="memory_title">Memory usage</string>
     <string name="memory_total">Total: <x:g id="total" example="100 MB">%s</x:g></string>
@@ -314,24 +313,25 @@
     <string name="memory_details_source">Source</string>
     <string name="memory_details_books">Books</string>
     <string name="memory_details_size">Size</string>
+
     <!-- Logs -->
     <string name="logs_title">Latest logs</string>
     <string name="logs_open">Open log</string>
     <string name="read_log">Read log</string>
     <string name="logs_share">Share log</string>
     <string name="no_error_detected">No errors detected.</string>
-    <string name="error_log_header" translatable="false">Error log for <x:g id="title">%1$s</x:g> [<x:g id="site_id">%2$s</x:g>@<x:g id="site_name">%3$s</x:g>]: <x:g id="error_count" example="2">%4$d</x:g> errors</string>
-    <string name="error_log_header_queue" translatable="false">Error log for queue</string>
     <string name="log_import_external">External library import/refresh</string>
     <string name="log_import">Primary library import/refresh</string>
     <string name="log_cleanup">Primary library cleanup</string>
     <string name="log_api29_migration">Library migration from Hentoid v1.11</string>
+
     <!-- Errors -->
     <string name="error_write_permission">You don\'t have permission to write in that folder, try another folder.</string>
     <string name="error_creating_folder">Folder is not valid.</string>
     <string name="error_open">Error opening file: no relevant application found</string>
     <string name="error_browser">Error opening link: no browser found</string>
     <string name="error_send">Error sending archive: no relevant application found</string>
+
     <!-- Error log -->
     <string name="redownload_dialog_title">Try downloading again\?</string>
     <string name="redownload_dialog_message">Total images in download: <x:g id="total_imgs" example="10">%1$d</x:g>\nImages without errors: <x:g id="fine_imgs" example="8">%2$d</x:g>\nImages with errors: <x:g id="failed_imgs" example="2">%3$d</x:g></string>
@@ -340,6 +340,7 @@
     <string name="redownload_open_log">Open error log</string>
     <string name="redownload_share_log">Share error log</string>
     <string name="redownload_generating_log_file">Generating log file…</string>
+
     <!-- Library fragment -->
     <string name="resume_closed">Resume reading from where you left\?</string>
     <string name="open_drawer">Open drawer</string>
@@ -394,14 +395,7 @@
     <string name="search_entry_not_found">That\'s not in here, go download it.</string>
     <string name="packaging_content">Packaging files.\nPlease wait…</string>
     <string name="search_bookid_label">Search <x:g id="launchcode" example="4567">\'%s\'</x:g> in…</string>
-    <string name="book_title" translatable="false">This is a rather long title, just because we need it to be.</string>
     <string name="book_launchcode">Launch code: <x:g id="launchcode" example="4567">%s</x:g></string>
-    <string name="book_series" translatable="false">Series: Name</string>
-    <string name="book_artist" translatable="false">Artist: In this book there are so many artists crammed in one place that one display line definitely can\'t contain them all</string>
-    <string name="book_pages_queue" translatable="false">Pages: 1234; estimated 125 MB</string>
-    <string name="book_pages_library" translatable="false">1234 pages / 1125 MB</string>
-    <string name="book_pages_library2" translatable="false">1234 pages / 30 chapters / 1125 MB [Merged]</string>
-    <string name="book_tags" translatable="false">tag1, tag2, tag3, etc.</string>
     <plurals name="number_of_items">
         <item quantity="one"><x:g id="count" example="1">%d</x:g> item</item>
         <item quantity="other"><x:g id="count" example="2">%d</x:g> items</item>
@@ -474,6 +468,7 @@
         <item quantity="other">Delete groups + books</item>
     </plurals>
     <string name="group_delete_nothing">Nothing to delete - check "Allow deleting external content" to change that</string>
+
     <!-- Merge & split -->
     <string name="merge_merge">Merge</string>
     <string name="merge_progress">Merging books…</string>
@@ -486,12 +481,14 @@
     <string name="split_create_chapters">Create chapters</string>
     <string name="merge_success">Content merged</string>
     <string name="split_success">Content split</string>
+
     <!-- Groups -->
     <string name="groups_flat">All books</string>
     <string name="groups_by_artist">By Artist</string>
     <string name="groups_by_dl_date">By Download date</string>
     <string name="groups_custom">Custom</string>
     <string name="no_artist_group_name">[no artist]</string>
+
     <!-- Sorting fields -->
     <string name="sort_title">Title</string>
     <string name="sort_artist">Artist</string>
@@ -505,17 +502,20 @@
     <string name="sort_custom">Custom</string>
     <string name="sort_invalid">-invalid-</string>
     <string name="sort_books">Books</string>
+
     <!-- Item card tooltips -->
     <string name="drag_help">Drag item</string>
     <string name="external_help">Belongs to the external library</string>
     <string name="streamed_help">Streamed book</string>
     <string name="view_source_help">View source in browser</string>
     <string name="fav_help">Mark/unmark as favourite</string>
+
     <!-- Visibility fields -->
     <string name="show_artists">Show artists</string>
     <string name="show_groups">Show groups</string>
     <string name="show_artists_and_groups">Show artists &amp; groups</string>
     <string name="launchcode_present">You already have this book. Search other sources\?</string>
+
     <!-- Updates -->
     <string name="updates_title">Updates</string>
     <string name="checking_updates">Checking for updates</string>
@@ -530,6 +530,7 @@
     <string name="error_network_summary">Network error, please try again later.</string>
     <string name="error_file">Cannot find update file on server.</string>
     <string name="update_check_no_update">Update Check: No new updates.</string>
+
     <!-- Alerts -->
     <string name="alert_orange">Be aware that downloads may fail on this site.</string>
     <string name="alert_red">The download button is currently broken for this site.</string>
@@ -537,6 +538,7 @@
     <string name="alert_black">This site is currently unavailable for real. The app has nothing to do about it. Please try again later.</string>
     <string name="alert_wip">The Hentoid dev team is working on a fix. You will be notified by the app when a new version is ready.</string>
     <string name="alert_fix_available">A fix is available on the latest version of the app. Please update.</string>
+
     <!-- App Lock -->
     <string name="app_lock_pin">Enter PIN</string>
     <string name="app_lock_pin_prefs">App Lock PIN</string>
@@ -550,17 +552,16 @@
     <string name="pin_new_confirm">Confirm New PIN</string>
     <string name="pin_explanation">App Lock prevents unauthorized use of this app by requiring a 4-digit PIN when launched</string>
     <string name="pin_lock_on_restore">Lock when restored\nfrom background</string>
+
     <!-- About Activity -->
     <string name="about1"><b>Hentoid</b> is a Doujinshi &amp; H-Manga archiving app. Hentoid was originally created by <b>Cesar Arasaki</b>.</string>
     <string name="personalDataStatement1"><b>PERSONAL DATA PRIVACY STATEMENT</b>\n\nHentoid is a free and open-source software maintained by the Hentoid Community (join us on Discord - see link above)</string>
     <string name="personalDataStatement2">Hentoid collects the following personal data and sends them to Google for processing through the firebase library:\n  - Session ID\n  - IP address</string>
     <string name="personalDataStatement3">The abovementioned data is removed from Firebase live and backup system within 180 days (see https://firebase.google.com/support/privacy/ for more details)\n\nNo other personal data is collected nor sent to any other party.</string>
-    <string name="about_github" translatable="false"><u>GitHub</u></string>
-    <string name="about_discord" translatable="false"><u>Discord</u></string>
-    <string name="about_reddit" translatable="false"><u>Reddit</u></string>
     <string name="about_licenses">Display Licenses</string>
     <string name="about_app_version" tools:ignore="MissingTranslation">Hentoid v<x:g id="ver_name" example="1.15.20">%1$s</x:g> (<x:g id="ver_code" example="130">%2$d</x:g>)</string>
     <string name="about_chrome_version" tools:ignore="MissingTranslation">Chrome v<x:g id="chrome_ver" example="98">%1$d</x:g></string>
+
     <!-- Web browser -->
     <string name="web_gallery">Back to latest gallery page</string>
     <string name="web_home">Back to library</string>
@@ -583,12 +584,14 @@
     <string name="bookmark_homepage">Homepage</string>
     <string name="torrent_dl_fail">Downloading torrent failed: <x:g id="torrent">%s</x:g></string>
     <string name="web_storage_permission_denied">Storage permission denied - cannot use the downloader</string>
+
     <!-- Web browser (site specifics) -->
     <string name="help_web_fakku_account">Please use or create a legit FAKKU account.\nHentoid won\'t work without it.</string>
     <string name="help_web_fakku_premium">That book can\'t be viewed with your current FAKKU access.</string>
     <string name="help_web_exh_account">Please use or create an exHentai account</string>
     <string name="help_web_invalid_exh_credentials">Invalid credentials, please log in again</string>
     <string name="help_web_incomplete_exh_credentials">Incomplete credentials, please log in again. If the issue persists, consider accessing the site from another country or creating a new account.</string>
+
     <!-- SearchActivity -->
     <string name="category_any">Any</string>
     <string name="exclude">Exclude</string>
@@ -603,33 +606,25 @@
     <string name="category_source">Source (<x:g id="count" example="2">%1$d</x:g>)</string>
     <!-- Used near items or in prompts (e.g. "Search artist"): Accusative case -->
     <string name="object_artist">Artist</string>
-    <!-- Used near items or in prompts (e.g. "Search artist"): Accusative case -->
     <string name="object_tag">Tag</string>
-    <!-- Used near items or in prompts (e.g. "Search artist"): Accusative case -->
     <string name="object_character">Character</string>
-    <!-- Used near items or in prompts (e.g. "Search artist"): Accusative case -->
     <string name="object_series">Series</string>
-    <!-- Used near items or in prompts (e.g. "Search artist"): Accusative case -->
     <string name="object_language">Language</string>
-    <!-- Used near items or in prompts (e.g. "Search artist"): Accusative case -->
     <string name="object_source">Source</string>
-    <!-- Used near items or in prompts (e.g. "Search artist"): Accusative case -->
     <string name="object_uploader">Uploader</string>
-    <!-- Used near items or in prompts (e.g. "Search artist"): Accusative case -->
     <string name="object_circle">Circle</string>
-    <!-- Used near items or in prompts (e.g. "Search artist"): Accusative case -->
     <string name="object_category">Category</string>
-    <!-- Used near items or in prompts (e.g. "Search artist"): Accusative case -->
     <string name="object_translator">Translator</string>
-    <!-- Used near items or in prompts (e.g. "Search artist"): Accusative case -->
     <string name="object_publisher">Publisher</string>
     <plurals name="search_button">
         <item quantity="one"><x:g id="count" example="1">%s</x:g> Result found</item>
         <item quantity="other"><x:g id="count" example="2">%s</x:g> Results found</item>
     </plurals>
     <string name="search_select_a_filter">Select a filter</string>
+
     <!-- DB migration & Maintenance -->
     <string name="maintenance">Performing maintenance</string>
+
     <!-- Image viewer -->
     <string name="no_images">Could not load the book: No image found</string>
     <string name="loading_archive">Loading: <x:g id="number" example="1">%1$d</x:g>/<x:g id="total" example="42">%2$d</x:g></string>
@@ -707,6 +702,7 @@
     <string name="slideshow_start">Starting slideshow (delay <x:g id="time" example="0.5">%.1f</x:g>s)</string>
     <string name="slideshow_stop">Slideshow stopped</string>
     <string name="ask_clear_chapters">Clear all chapters?</string>
+
     <!-- Changelog -->
     <string name="view_changelog">View changelog</string>
     <string name="view_changelog_flagged">View changelog*</string>
@@ -714,8 +710,10 @@
     <string name="get_latest">Get the latest version (<x:g id="version" example="1.18.1">%1$s</x:g>)</string>
     <string name="update_success">Update successful!</string>
     <string name="starting_download">Starting download</string>
+
     <!-- Edit drawer -->
     <string name="title_activity_drawer_edit">Edit menu</string>
+
     <!-- Duplicate detector -->
     <string name="title_activity_duplicate_detector">Duplicate detector</string>
     <string name="duplicate_use_title">Title</string>
@@ -742,7 +740,6 @@
     <string name="duplicate_cover_score_nodata">Cover: no data</string>
     <string name="duplicate_artist_score">Artist: <x:g id="similarity_percentage" example="50%">%.0f%%</x:g></string>
     <string name="duplicate_artist_score_nodata">Artist: no data</string>
-    <string name="duplicate_total_score" translatable="false">%.0f%%</string>
     <string name="apply_processing">Apply (<x:g id="remaining" example="5">%d</x:g> remaining choices)</string>
     <string name="apply_final">Apply choices</string>
     <string name="duplicate_notif_start">Starting duplicate detection</string>
@@ -760,6 +757,7 @@
     <string name="duplicate_empty_no_result">No duplicates found</string>
     <string name="duplicate_keep">Keep</string>
     <string name="duplicate_delete">Delete</string>
+
     <!-- Duplicate dialog -->
     <string name="duplicate_alert">Duplicate alert!</string>
     <string name="duplicate_alert_subtitle_book">The book you\'re about to download may be a duplicate of a book you already own.</string>
@@ -772,6 +770,7 @@
     <string name="duplicate_alert_download_book">Download book</string>
     <string name="duplicate_alert_download_pages">Download extra pages</string>
     <string name="duplicate_wait_index">Indexing…</string>
+
     <!-- Generic delete & purge -->
     <string name="notif_archive_title">Content archival</string>
     <string name="notif_delete_title">Content deletion</string>
@@ -782,10 +781,12 @@
     </plurals>
     <string name="notif_delete_fail">Deletion failed</string>
     <string name="notif_delete_fail_details">At least one book failed to be deleted</string>
+
     <!-- Startup -->
     <string name="title_startup">Startup</string>
     <string name="title_startup_progress">Starting…</string>
     <string name="title_startup_complete">Startup complete</string>
+
     <!-- Group names -->
     <string name="group_today">Today</string>
     <string name="group_7">Last 7 days</string>
@@ -794,10 +795,12 @@
     <string name="group_year">Last year</string>
     <string name="group_long">A long time ago</string>
     <string name="group_no_group">Ungrouped</string>
+
     <!-- Themes -->
     <string name="theme_light">Light</string>
     <string name="theme_deep_red">Deep Red</string>
     <string name="theme_dark">Dark</string>
+
     <!-- Book languages detected by the app -->
     <string name="lang_en">english</string>
     <string name="lang_zh">chinese</string>
@@ -816,6 +819,7 @@
     <string name="lang_hu">hungarian</string>
     <string name="lang_tr">turkish</string>
     <string name="lang_cs">czech</string>
+
     <!-- Misc -->
     <string name="select_file_manager">Select your file manager</string>
     <string name="default_permission">Default permission</string>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:x="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="pref_generic_summary" translatable="false">%s</string>
     <!-- Interface -->
     <string name="pref_screen_interface">Interface &amp; Navigation</string>
     <string name="pref_cat_library">Library</string>
@@ -8,26 +7,20 @@
     <string name="pref_drawer_sources_summary">Enable, disable and reorganize sources appearing on the left navigation drawer</string>
     <string name="pref_library_display_title">Display type</string>
     <string name="pref_library_display_summary">Type of display for books and groups\nCurrent: <x:g id="display_type" example="List">%s</x:g></string>
-    <string name="pref_library_display_default" translatable="false">0</string>
     <string name="pref_endless_scroll_title">Endless Scroll</string>
     <string name="pref_endless_scroll_summary_off">Enable endless scrolling in download list\nDisables paging</string>
     <string name="pref_endless_scroll_summary_on">Scroll away to your heart\'s content</string>
-    <string name="pref_endless_scroll_default" translatable="false">true</string>
     <string name="pref_quantity_per_page_title">Quantity Per Page</string>
     <string name="pref_quantity_per_page_summary">Number of items per page in download list\nCurrently: <x:g id="count" example="10">%s</x:g> items</string>
-    <string name="pref_quantity_per_page_default" translatable="false">20</string>
     <string name="pref_cat_search">Advanced search</string>
     <string name="pref_attributes_list_order_title">Sorting order of displayed metadata</string>
-    <string name="pref_attributes_list_order_default" translatable="false">1</string>
-    <string name="pref_attributes_list_order_summary" translatable="false">%s</string>
     <string name="pref_attributes_list_count_title">Count available books</string>
     <string name="pref_attributes_list_count_on">The number of available books is displayed next to every attribute</string>
     <string name="pref_attributes_list_count_off">The number of available books is not displayed</string>
-    <string name="pref_attributes_list_count_default" translatable="false">true</string>
     <string name="pref_cat_theme">App theme</string>
     <string name="pref_color_theme_title">Color theme</string>
     <string name="pref_color_theme_summary">Current theme: <x:g id="theme_name" example="Deep Red">%s</x:g></string>
-    <string name="pref_color_theme_default" translatable="false">0</string>
+
     <!-- Storage -->
     <string name="pref_screen_storage">Storage</string>
     <string name="pref_cat_downloads_folder">Hentoid library</string>
@@ -36,27 +29,22 @@
     <string name="pref_import_queue_empty_title">Queue empty books as errors</string>
     <string name="pref_import_queue_empty_on">Empty books will be added to the queue as errors</string>
     <string name="pref_import_queue_empty_off">Empty books will be added to the library</string>
-    <string name="pref_import_queue_empty_default" translatable="false">false</string>
     <string name="pref_folder_naming_content_title">Folder names</string>
     <string name="pref_folder_naming_content_summary">Book folder naming convention:\n<x:g id="convention" example="Name - ID">%s</x:g></string>
-    <string name="pref_folder_naming_content_default" translatable="false">2</string>
     <string name="pref_import_running">Import is already running</string>
     <string name="prefs_ask_detach_external_library">Detach the external library\?</string>
     <string name="prefs_external_library_detached">External library detached</string>
     <string name="pref_folder_trunc_title">Truncate folder name</string>
     <string name="pref_folder_trunc_summary">Book folder name truncation\nCurrently: <x:g id="chars" example="80 characters">%s</x:g></string>
-    <string name="pref_folder_trunc_default" translatable="false">100</string>
     <string name="pref_memory_usage_title">Memory usage</string>
     <string name="pref_memory_usage_summary">Current free space: <x:g id="percentage" example="13.37%">%.2f%%</x:g> (tap for details)</string>
     <string name="pref_memory_alert_title">Alert on low memory</string>
-    <string name="pref_memory_alert_default" translatable="false">110</string>
     <string name="pref_cat_external">External library</string>
     <string name="pref_external_library_title">External library</string>
     <string name="pref_external_library_summary_empty">No external library is set</string>
     <string name="pref_external_library_delete_title">Allow deleting external content</string>
     <string name="pref_external_library_delete_on">Hentoid can delete books and pages in the external library</string>
     <string name="pref_external_library_delete_off">Hentoid can\'t delete books nor pages in the external library</string>
-    <string name="pref_external_library_delete_default" translatable="false">false</string>
     <string name="pref_external_library_detach_title">Detach external library</string>
     <string name="pref_external_library_detach_summary">Don\'t include the external library into Hentoid anymore</string>
     <string name="pref_cat_advanced">Advanced</string>
@@ -68,38 +56,30 @@
         <item quantity="one">Delete <x:g id="count" example="1">%d</x:g> book\?</item>
         <item quantity="other">Delete <x:g id="count" example="2">%d</x:g> books\?</item>
     </plurals>
+
     <!-- Browser -->
     <string name="pref_screen_browser">Browser</string>
     <string name="pref_browser_behaviour">Behaviour</string>
     <string name="pref_browser_resume_last_title">Resume at last viewed page</string>
     <string name="pref_browser_resume_last_off">Any site always opens on its homepage</string>
     <string name="pref_browser_resume_last_on">Any site opens on its last viewed page</string>
-    <string name="pref_browser_resume_last_default" translatable="false">false</string>
     <string name="pref_browser_dl_action_title">Download action</string>
-    <string name="pref_browser_dl_action_default" translatable="false">0</string>
     <string name="pref_browser_quick_dl_title">Quick download</string>
     <string name="pref_browser_quick_dl_summary">On the books list page, hold tap to download any book</string>
-    <string name="pref_browser_quick_dl_default" translatable="false">true</string>
     <string name="pref_browser_nhentai_invisible_blacklist_title">Hide nhentai-blacklisted books</string>
     <string name="pref_browser_nhentai_invisible_blacklist_off">Nhentai-blacklisted books are blurred</string>
     <string name="pref_browser_nhentai_invisible_blacklist_on">Nhentai-blacklisted books are invisible</string>
-    <string name="pref_browser_nhentai_invisible_blacklist_default" translatable="false">false</string>
     <string name="pref_browser_quick_dl_threshold_title">Quick download long press threshold</string>
     <string name="pref_browser_quick_dl_threshold_summary">Hold down for this duration to start quick downloading\nCurrent: <x:g id="time" example="1 s">%s</x:g></string>
-    <string name="pref_browser_quick_dl_threshold_default" translatable="false">500</string>
-    <string name="pref_browser_augmented_default" translatable="false">true</string>
     <string name="pref_browser_duplicate_ask_title">Duplicates checking</string>
     <string name="pref_browser_duplicate_ask_off">No: always download</string>
     <string name="pref_browser_duplicate_ask_on">Yes: ask before downloading</string>
-    <string name="pref_browser_duplicate_ask_default" translatable="false">true</string>
     <string name="pref_browser_duplicate_try_pages_title">Try finding extra pages on potential duplicates\?</string>
     <string name="pref_browser_duplicate_try_pages_off">Only try finding extra pages on the original book</string>
     <string name="pref_browser_duplicate_try_pages_on">Try finding extra pages on potential duplicates</string>
-    <string name="pref_browser_duplicate_try_pages_default" translatable="false">true</string>
     <string name="pref_browser_mark_downloaded_title">Mark downloaded books</string>
     <string name="pref_browser_mark_downloaded_off">Downloaded books have no special display</string>
     <string name="pref_browser_mark_downloaded_on">Downloaded books are marked\nNB: does not work on all sites</string>
-    <string name="pref_browser_mark_downloaded_default" translatable="false">false</string>
     <string name="pref_browser_visuals">Visuals</string>
     <string name="pref_browser_augmented_title">Augmented browser</string>
     <string name="pref_browser_augmented_off">Using vanilla behaviour</string>
@@ -107,57 +87,41 @@
     <string name="pref_browser_override_overview_title">Disable Page Overview</string>
     <string name="pref_browser_override_overview_summary_off">Disables page overview and allows you to set your preferred initial zoom level below</string>
     <string name="pref_browser_override_overview_summary_on">Tweak the setting below to set your initial zoom level\nNote: Only affects hitomi and e-hentai</string>
-    <string name="pref_browser_override_overview_default" translatable="false">false</string>
     <string name="pref_browser_initial_zoom_title">Initial Zoom Level</string>
     <string name="pref_browser_initial_zoom_summary">Zoom level of browser page on initial page load\nCurrently: <x:g id="percentage" example="20%">%s%%</x:g></string>
-    <string name="pref_browser_initial_zoom_default" translatable="false">20</string>
     <string name="pref_browser_dns">Custom DNS</string>
     <string name="pref_browser_dns_title">DNS over HTTPS</string>
-    <string name="pref_browser_dns_default" translatable="false">-1</string>
+
     <!-- Downloader -->
     <string name="pref_screen_downloader">Downloader</string>
     <string name="pref_queue_autostart_title">Auto-start download queue</string>
-    <string name="pref_queue_autostart_default" translatable="false">true</string>
     <string name="pref_queue_autostart_on">Download queue will start as soon as a download is done</string>
     <string name="pref_queue_autostart_off">Download queue must be started manually</string>
     <string name="pref_queue_wifi_only_title">Only download on Wi-Fi</string>
-    <string name="pref_queue_wifi_only_default" translatable="false">false</string>
     <string name="pref_queue_wifi_only_on">Download queue will only start if connected to Wi-Fi</string>
     <string name="pref_queue_wifi_only_off">Download queue will start if the device is connected to any network</string>
     <string name="pref_queue_new_position_title">New downloads position</string>
-    <string name="pref_queue_new_position_default" translatable="false">1</string>
     <string name="download_size_wifi_title">Skip large downloads on mobile data</string>
-    <string name="pref_dl_size_wifi_default" translatable="false">false</string>
     <string name="pref_dl_size_wifi_on">Large downloads will be skipped if not connected to Wi-Fi</string>
     <string name="pref_dl_size_wifi_off">All downloads will be processed</string>
     <string name="pref_dl_size_wifi_threshold_title">Size threshold for large downloads</string>
-    <string name="pref_dl_size_wifi_threshold_default" translatable="false">40</string>
     <string name="pref_dl_pages_wifi_threshold_title">Large downloads pages threshold</string>
-    <string name="pref_dl_pages_wifi_threshold_default" translatable="false">999999</string>
     <string name="download_retries_screen_title">Automated download retries</string>
     <string name="download_retries_active_title">Retries activated</string>
-    <string name="pref_dl_retries_active_default" translatable="false">false</string>
     <string name="pref_dl_retries_on">Failed downloads will auto-retry</string>
     <string name="pref_dl_retries_off">Failed downloads will stay in error state</string>
     <string name="pref_dl_retries_number_title">Number of retries before aborting</string>
-    <string name="pref_dl_retries_number_summary" translatable="false">%s</string>
-    <string name="pref_dl_retries_number_default" translatable="false">3</string>
     <string name="pref_dl_retries_mem_limit_title">Mem usage threshold before aborting</string>
-    <string name="pref_dl_retries_mem_limit_summary" translatable="false">%s</string>
-    <string name="pref_dl_retries_mem_limit_default" translatable="false">100</string>
     <string name="tag_blocking_screen_title">Tag blocking</string>
     <string name="pref_dl_blocked_tags_title">Blocked tags</string>
     <string name="pref_dl_blocked_tags_summary">Block the download of books with specific tags\nTip: separate tags with commas</string>
     <string name="pref_dl_blocked_tags_behaviour_title">Blocking behaviour</string>
-    <string name="pref_dl_blocked_tags_behaviour_default" translatable="false">0</string>
-    <string name="pref_dl_hitomi" translatable="false">Hitomi.la</string>
     <string name="pref_dl_hitomi_webp_title">Prefer downloading WebP</string>
     <string name="pref_dl_hitomi_webp_summary_off">Download other type of pictures (PNG, JPG)</string>
     <string name="pref_dl_hitomi_webp_summary_on">Download WebP pictures whenever they are available</string>
-    <string name="pref_dl_hitomi_webp_default" translatable="false">true</string>
     <string name="pref_dl_threads_quantity_title">Number of parallel downloads</string>
     <string name="pref_dl_threads_quantity_summary">Number of images downloaded simultaneously\nCurrently: <x:g id="number" example="5">%s</x:g></string>
-    <string name="pref_dl_threads_quantity_default" translatable="false">0</string>
+
     <!-- Privacy -->
     <string name="pref_screen_privacy">Privacy</string>
     <string name="pref_app_preview_title">App preview on Recent Apps</string>
@@ -166,11 +130,10 @@
     <string name="pref_screenshot_title">Enable screenshots</string>
     <string name="pref_screenshot_summary_off">App preview in Recent Apps + screenshots disabled</string>
     <string name="pref_screenshot_summary_on">Screenshots enabled</string>
-    <string name="pref_app_preview_default" translatable="false">false</string>
     <string name="pref_analytics_preference_title">Firebase Analytics</string>
     <string name="pref_analytics_preference_summary_off">Analytics Tracking is currently disabled.\nEnabling it will help us improve the app by tracking crashes &amp; exceptions.</string>
     <string name="pref_analytics_preference_summary_on">Analytics Tracking is on.\nThanks for helping improve Hentoid!</string>
-    <string name="pref_analytics_preference_default" translatable="false">true</string>
+
     <!-- Updates -->
     <string name="pref_screen_updates">Updates</string>
     <string name="pref_check_updates_manual_title">Manual Update Check</string>
@@ -181,68 +144,44 @@
     <string name="pref_check_updates_title">Automatic Updates</string>
     <string name="pref_check_updates_summary_off">Enable automatic update checks over mobile data</string>
     <string name="pref_check_updates_summary_on">Note: Does not override manual update checks</string>
-    <string name="pref_check_updates_default" translatable="false">true</string>
+
     <!-- Viewer -->
     <string name="pref_screen_viewer">Image viewer</string>
     <string name="pref_viewer_controls">Controls</string>
     <string name="pref_viewer_browse_mode">Browse mode</string>
-    <string name="pref_viewer_browse_mode_default" translatable="false">0</string>
     <string name="pref_viewer_page_turn">Page turn control</string>
     <string name="pref_viewer_page_turn_swipe">Swipe</string>
-    <bool name="pref_viewer_page_turn_swipe_default" translatable="false">true</bool>
     <string name="pref_viewer_page_turn_tap">Border tap</string>
-    <bool name="pref_viewer_page_turn_tap_default" translatable="false">true</bool>
     <string name="pref_viewer_page_turn_tap_2x">Tap zone width x2</string>
-    <bool name="pref_viewer_page_turn_tap_2x_default" translatable="false">false</bool>
     <string name="pref_viewer_page_turn_volume">Volume button</string>
-    <bool name="pref_viewer_page_turn_volume_default" translatable="false">true</bool>
     <string name="pref_viewer_page_turn_keyboard">Keyboard left/right</string>
-    <bool name="pref_viewer_page_turn_keyboard_default" translatable="false">true</bool>
     <string name="pref_viewer_swipe_to_fling">Swipe to fling</string>
-    <bool name="pref_viewer_swipe_to_fling_default" translatable="false">false</bool>
     <string name="pref_viewer_invert_volume">Invert volume buttons</string>
-    <bool name="pref_viewer_invert_volume_default" translatable="false">false</bool>
     <string name="pref_viewer_zoom">Zoom</string>
     <string name="pref_viewer_zoom_holding">Temp zoom while holding</string>
-    <bool name="pref_viewer_zoom_holding_default" translatable="false">false</bool>
     <string name="pref_viewer_cap_tap_zoom">Cap double &amp; long tap zoom</string>
-    <string name="pref_viewer_cap_tap_zoom_default" translatable="false">0</string>
     <string name="pref_viewer_visuals">Visuals</string>
     <string name="pref_viewer_keep_screen_on">Keep screen on</string>
-    <bool name="pref_viewer_keep_screen_on_default" translatable="false">true</bool>
     <string name="pref_viewer_display_pagenum">Always display page number</string>
-    <bool name="pref_viewer_display_pagenum_default" translatable="false">false</bool>
     <string name="pref_viewer_tap_transitions">Enable page turn animation</string>
-    <bool name="pref_viewer_tap_transitions_default" translatable="false">true</bool>
     <string name="pref_viewer_zoom_transitions">Enable zoom animation</string>
-    <bool name="pref_viewer_zoom_transitions_default" translatable="false">true</bool>
     <string name="pref_viewer_separating_bars">Separating bars in vertical mode</string>
-    <string name="pref_viewer_separating_bars_default" translatable="false">0</string>
     <string name="pref_viewer_display_mode">Display mode for horizontal viewing</string>
-    <string name="pref_viewer_display_mode_default" translatable="false">0</string>
     <string name="pref_viewer_rendering">Rendering mode</string>
-    <string name="pref_viewer_rendering_default" translatable="false">0</string>
     <string name="pref_viewer_rendering_no_android5">Smooth rendering is not available on Android 5</string>
     <string name="pref_viewer_auto_rotate">Auto-rotate pictures</string>
-    <bool name="pref_viewer_auto_rotate_default" translatable="false">false</bool>
     <string name="pref_viewer_auto_rotate_summary_off">Pictures are not rotated</string>
     <string name="pref_viewer_auto_rotate_summary_on">Pictures are rotated to best occupy the screen</string>
     <string name="pref_viewer_gallery_columns">Number of columns for gallery</string>
-    <string name="pref_viewer_gallery_columns_default" translatable="false">4</string>
     <string name="pref_viewer_navigation">Navigation &amp; behaviour</string>
     <string name="pref_viewer_resume_last_left_title">Resume reading when reopening books</string>
     <string name="pref_viewer_resume_last_left_summary_off">Reopening a book always starts at page 1</string>
     <string name="pref_viewer_resume_last_left_summary_on">Reopening a book resumes on last read page, except if the end of the book has been reached</string>
-    <bool name="pref_viewer_resume_last_left_default" translatable="false">true</bool>
     <string name="pref_viewer_open_gallery">Always open in gallery mode</string>
-    <bool name="pref_viewer_open_gallery_default" translatable="false">false</bool>
     <string name="pref_viewer_continuous_title">Continuous reading</string>
     <string name="pref_viewer_continuous_summary_off">Using next page on last page has no effect</string>
     <string name="pref_viewer_continuous_summary_on">Using next page on last page loads the next book</string>
-    <bool name="pref_viewer_continuous_default" translatable="false">false</bool>
     <string name="pref_viewer_read_threshold">Mark book as read after N pages</string>
-    <string name="pref_viewer_read_threshold_default" translatable="false">0</string>
     <string name="pref_viewer_slideshow_delay">Slideshow / Delay between each page</string>
-    <string name="pref_viewer_slideshow_delay_default" translatable="false">0</string>
     <string name="doh_warning">Some websites won\'t work well with DNS over HTTPS. Use an external DNS app if you experience issues during navigation (e.g. blank pages, unresponsive login forms)</string>
 </resources>


### PR DESCRIPTION
**Implements Feature:** Reformatted resource files and RU additions
<br />

Summary of changes in this PR:

- Strings marked as `translatable="false"` are moved to the easy-to-navigate `donottranslate.xml` file

- Weblate-styled comments are reverted to an easier-to-read style

- Translated language names for RU

<br />
@AVnetWS/admin-team
