### PR TITLE
Unhandled exception on app's startup when WebView is not available on the system

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,10 @@
         android:usesCleartextTraffic="true"
         tools:replace="android:allowBackup, android:supportsRtl, android:extractNativeLibs">
         <activity
+            android:name=".activities.MissingWebViewActivity"
+            android:exported="false"
+            android:noHistory="true" />
+        <activity
             android:name=".activities.SplashActivity"
             android:exported="true"
             android:noHistory="true">

--- a/app/src/main/java/me/devsaki/hentoid/activities/MissingWebViewActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/MissingWebViewActivity.java
@@ -1,0 +1,19 @@
+package me.devsaki.hentoid.activities;
+
+import android.os.Bundle;
+import android.view.View;
+
+import me.devsaki.hentoid.R;
+
+public class MissingWebViewActivity extends BaseActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_missing_web_view);
+    }
+
+    public void onCloseHentoidPressed(View v) {
+        System.exit(0);
+    }
+}

--- a/app/src/main/java/me/devsaki/hentoid/activities/SplashActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/SplashActivity.java
@@ -3,6 +3,7 @@ package me.devsaki.hentoid.activities;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
+import android.webkit.CookieManager;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -40,12 +41,16 @@ public class SplashActivity extends BaseActivity {
 
         Timber.d("Splash / Init");
 
-        new AppStartup().initApp(
-                this,
-                this::displayMainProgress,
-                this::displaySecondaryProgress,
-                this::followStartupFlow
-        );
+        if (!isWebViewInstalled())
+            startActivity(new Intent(this, MissingWebViewActivity.class));
+        else {
+            new AppStartup().initApp(
+                    this,
+                    this::displayMainProgress,
+                    this::displaySecondaryProgress,
+                    this::followStartupFlow
+            );
+        }
     }
 
     private void displayMainProgress(Float progress) {
@@ -117,5 +122,20 @@ public class SplashActivity extends BaseActivity {
         intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         intent = UnlockActivity.wrapIntent(this, intent);
         goToActivity(intent);
+    }
+
+    /**
+     * Checks whether WebView is available and ready to use. (as opposed to `getPackageManager().
+     * hasSystemFeature(..)`, which falsely returns true if it's disabled)
+     *
+     * @return true if WebView is installed and enabled, false otherwise.
+     */
+    private boolean isWebViewInstalled() {
+        try {
+            CookieManager.getInstance();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/app/src/main/java/me/devsaki/hentoid/core/HentoidApp.java
+++ b/app/src/main/java/me/devsaki/hentoid/core/HentoidApp.java
@@ -134,8 +134,12 @@ public class HentoidApp extends Application {
 
         // Init user agents (must be done here as some users seem not to complete AppStartup properly)
         Timber.i("Init user agents : start");
-        HttpHelper.initUserAgents(this);
-        Timber.i("Init user agents : done");
+        try {
+            HttpHelper.initUserAgents(this);
+            Timber.i("Init user agents : done");
+        } catch (Exception MissingWebViewPackageException) {
+            Timber.e("Failed to init user agents: No WebView installed");
+        }
     }
 
     public static boolean isInForeground() {

--- a/app/src/main/res/layout/activity_missing_web_view.xml
+++ b/app/src/main/res/layout/activity_missing_web_view.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/primary_light"
+    tools:context=".activities.MissingWebViewActivity">
+
+    <TextView
+        android:id="@+id/missing_web_view_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:gravity="center"
+        android:paddingStart="10sp"
+        android:paddingEnd="10sp"
+        android:text="@string/missing_web_view_title"
+        android:textSize="24sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/missing_web_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:paddingStart="10sp"
+        android:paddingEnd="10sp"
+        android:text="@string/missing_web_view"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/missing_web_view_title" />
+
+    <Button
+        android:id="@+id/close_hentoid"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:onClick="onCloseHentoidPressed"
+        android:paddingStart="10sp"
+        android:paddingEnd="10sp"
+        android:text="@string/missing_web_view_close"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/missing_web_view" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-ru/array_preferences.xml
+++ b/app/src/main/res/values-ru/array_preferences.xml
@@ -71,13 +71,20 @@
     <string name="pref_viewer_read_threshold_entries_2">2 страницы</string>
     <string name="pref_viewer_read_threshold_entries_3">5 страниц</string>
     <string name="pref_viewer_read_threshold_entries_4">Все страницы</string>
-    <!-- Choice for "Slideshow delay" setting -->
+    <!-- Choice for "Slideshow delay" setting for horizontal mode -->
     <string name="pref_viewer_slideshow_delay_entries_1">500 мс</string>
     <string name="pref_viewer_slideshow_delay_entries_2">1 с</string>
     <string name="pref_viewer_slideshow_delay_entries_3">2 с (по умолчанию)</string>
     <string name="pref_viewer_slideshow_delay_entries_4">4 с</string>
     <string name="pref_viewer_slideshow_delay_entries_5">8 с</string>
     <string name="pref_viewer_slideshow_delay_entries_6">16 с</string>
+    <!-- Choice for "Slideshow delay" setting for vertical mode -->
+    <string name="pref_viewer_slideshow_delay_entries_vertical_1">Очень медленная</string>
+    <string name="pref_viewer_slideshow_delay_entries_vertical_2">Медленная</string>
+    <string name="pref_viewer_slideshow_delay_entries_vertical_3">Обычная (по умолчанию)</string>
+    <string name="pref_viewer_slideshow_delay_entries_vertical_4">Быстрая</string>
+    <string name="pref_viewer_slideshow_delay_entries_vertical_5">Ещё быстрее</string>
+    <string name="pref_viewer_slideshow_delay_entries_vertical_6">Очень быстрая</string>
     <!-- Choice for "Display mode" setting -->
     <string name="pref_viewer_display_mode_entries_1">По размеру экрана (по умолчанию)</string>
     <string name="pref_viewer_display_mode_entries_2">Заполнить экран</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -825,6 +825,11 @@
     <string name="title_startup_progress">Запускается…</string>
     <string name="title_startup_complete">Запуск завершён</string>
 
+    <!-- Missing WebView -->
+    <string name="missing_web_view_title">WebView не установлен или отключён</string>
+    <string name="missing_web_view">Hentoid не обнаружил встроенный специальный браузер Android.\nК сожалению, приложение не может работать без него.\n\nСкорее всего, он на самом деле установлен у вас, просто отключён: пожалуйста, перейдите в <b>Настройки</b> &gt; <b>Приложения</b> &gt; <b>Отключённые</b> и включите <b>Android System WebView</b>.\n\nЕсли вы не можете найти такое приложение, пожалуйста, установите его из <b><a href="https://play.google.com/store/apps/details?id=com.google.android.webview">Play Маркета</a></b>.</string>
+    <string name="missing_web_view_close">Закрыть Hentoid</string>
+
     <!-- Group names -->
     <string name="group_today">Сегодня</string>
     <string name="group_7">На неделе</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -37,6 +37,7 @@
     <string name="cancel">Отменить</string>
     <string name="cancel_all">Отменить всё</string>
     <string name="menu_completed_single">Завершено</string>
+    <string name="menu_reset_read">Пометить непрочитанным</string>
     <string name="service_running">Сервис уже запущен</string>
     <string name="open_folder">Открыть папку</string>
     <string name="_default">по умолчанию</string>
@@ -100,6 +101,7 @@
     <string name="low_memory">Заканчивается память на устройстве!</string>
     <string name="fix_permissions">Исправить</string>
     <string name="view_queue">Просмотреть очередь</string>
+    <string name="clear_search_history">Очистить историю поиска</string>
 
     <!-- Queue / Downloader -->
     <string name="downloader_title">Загрузчик</string>
@@ -733,6 +735,7 @@
     <string name="chapters_remove_failed">Не удалось удалить главы</string>
     <string name="chapter_move_failed">Не удалось переместить главу</string>
     <string name="slideshow_start">Начало слайдшоу (задержка в <x:g id="time" example="0.5">%.1f</x:g> с)</string>
+    <string name="slideshow_start_vertical">Начало слайдшоу (<x:g example="быстро" id="speed">%s</x:g>)</string>
     <string name="slideshow_stop">Слайдшоу остановлено</string>
     <string name="ask_clear_chapters">Удалить все главы?</string>
 

--- a/app/src/main/res/values-ru/strings_settings.xml
+++ b/app/src/main/res/values-ru/strings_settings.xml
@@ -31,9 +31,9 @@
     <string name="pref_cat_downloads_folder">Библиотека Hentoid</string>
     <string name="pref_select_folder_title">Выбор папки загрузок</string>
     <string name="pref_select_folder_summary">Выберите, где Hentoid будет хранить ваши загрузки</string>
-    <string name="pref_import_queue_empty_title">Добавлять пустые книги в очередь как неудачные загрузки</string>
-    <string name="pref_import_queue_empty_on">Пустые книги будут добавлены в очередь как ошибки загрузки</string>
-    <string name="pref_import_queue_empty_off">Пустые книги будут добавлены в библиотеку</string>
+    <string name="pref_import_queue_empty_title">Добавлять пустые импортированные книги в очередь как неудачные загрузки</string>
+    <string name="pref_import_queue_empty_on">Пустые импортированные книги будут добавлены в очередь как ошибки загрузки</string>
+    <string name="pref_import_queue_empty_off">Пустые импортированные книги будут добавлены в библиотеку</string>
     <string name="pref_folder_naming_content_title">Названия папок</string>
     <string name="pref_folder_naming_content_summary">Способ наименования папок:\n<x:g id="convention" example="Название - ID">%s</x:g></string>
     <string name="pref_import_running">Импортирование уже запущено</string>

--- a/app/src/main/res/values-ru/strings_settings.xml
+++ b/app/src/main/res/values-ru/strings_settings.xml
@@ -162,11 +162,14 @@
     <string name="pref_viewer_page_turn_keyboard">Стрелки влево/вправо на клавиатуре</string>
     <string name="pref_viewer_swipe_to_fling">Перелистывать несколько страниц одним свайпом</string>
     <string name="pref_viewer_invert_volume">Инвертировать кнопки громкости</string>
+    <string name="pref_viewer_book_switch">Переключение книг</string>
+    <string name="pref_viewer_book_switch_volume">Кнопки громкости (долгое нажатие)</string>
     <string name="pref_viewer_zoom">Увеличение</string>
     <string name="pref_viewer_zoom_holding">Временно увеличивать при удержании пальца</string>
     <string name="pref_viewer_cap_tap_zoom">Ограничить зум по двойному или долгому нажатию</string>
     <string name="pref_viewer_visuals">Внешний вид</string>
     <string name="pref_viewer_keep_screen_on">Не выключать экран</string>
+    <string name="pref_viewer_display_notch">Показывать возле "чёлки"</string>
     <string name="pref_viewer_display_pagenum">Всегда показывать номер страницы</string>
     <string name="pref_viewer_tap_transitions">Включить анимацию смены страниц</string>
     <string name="pref_viewer_zoom_transitions">Включить анимацию зума</string>
@@ -188,5 +191,6 @@
     <string name="pref_viewer_continuous_summary_on">С последней страницы книги можно уйти на следующую книгу</string>
     <string name="pref_viewer_read_threshold">Считать книгу прочитанной после N страниц</string>
     <string name="pref_viewer_slideshow_delay">Слайдшоу / Время показа каждой страницы</string>
+    <string name="pref_viewer_slideshow_delay_vertical">Слайдшоу / Скорость вертикального пролистывания</string>
     <string name="doh_warning">Некоторые сайты плохо работают с DNS через HTTPS. Воспользуйтесь сторонним приложением для DNS, если вы испытываете проблемы при навигации (напрмер: пустые страницы или ошибки при авторизации)</string>
 </resources>

--- a/app/src/main/res/values-ru/strings_tools.xml
+++ b/app/src/main/res/values-ru/strings_tools.xml
@@ -20,4 +20,9 @@
 <string name="tools_cache_app_success">Кэш приложения успешно очищен</string>
 <string name="tools_latest_logs_title">Логи приложения</string>
 <string name="tools_latest_logs_summary">Просмотреть последние логи приложения</string>
+    <string name="tools_import_empty_books_intro">Если не обнаружено папки с изображениями…</string>
+    <string name="tools_import_empty_books_entries_1">Не импортировать</string>
+    <string name="tools_import_empty_books_entries_2">Импортировать как пустую книгу</string>
+    <string name="tools_import_empty_books_entries_3">Импортировать для стриминга, если возможно</string>
+    <string name="tools_import_empty_books_entries_4">Добавить в очередь ошибок</string>
 </resources>

--- a/app/src/main/res/values-uk/array_preferences.xml
+++ b/app/src/main/res/values-uk/array_preferences.xml
@@ -71,13 +71,20 @@
     <string name="pref_viewer_read_threshold_entries_2">2 сторінки</string>
     <string name="pref_viewer_read_threshold_entries_3">5 сторінок</string>
     <string name="pref_viewer_read_threshold_entries_4">Всі сторінки</string>
-    <!-- Choice for "Slideshow delay" setting -->
+    <!-- Choice for "Slideshow delay" setting for hortizontal mode -->
     <string name="pref_viewer_slideshow_delay_entries_1">500 мс</string>
     <string name="pref_viewer_slideshow_delay_entries_2">1 с</string>
     <string name="pref_viewer_slideshow_delay_entries_3">2 с (за замовчуванням)</string>
     <string name="pref_viewer_slideshow_delay_entries_4">4 с</string>
     <string name="pref_viewer_slideshow_delay_entries_5">8 с</string>
     <string name="pref_viewer_slideshow_delay_entries_6">16 с</string>
+    <!-- Choice for "Slideshow delay" setting for vertical mode -->
+    <string name="pref_viewer_slideshow_delay_entries_vertical_1">Дуже повільна</string>
+    <string name="pref_viewer_slideshow_delay_entries_vertical_2">Повільна</string>
+    <string name="pref_viewer_slideshow_delay_entries_vertical_3">Звичайна (за замовчуванням)</string>
+    <string name="pref_viewer_slideshow_delay_entries_vertical_4">Швидка</string>
+    <string name="pref_viewer_slideshow_delay_entries_vertical_5">Ще швидше</string>
+    <string name="pref_viewer_slideshow_delay_entries_vertical_6">Дуже швидка</string>
     <!-- Choice for "Display mode" setting -->
     <string name="pref_viewer_display_mode_entries_1">За розміром екрану (за замовчуванням)</string>
     <string name="pref_viewer_display_mode_entries_2">Заповнити екран</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -36,6 +36,7 @@
     <string name="cancel">Скасувати</string>
     <string name="cancel_all">Скасувати все</string>
     <string name="menu_completed_single">Завершено</string>
+    <string name="menu_reset_read">Позначити непрочитаним</string>
     <string name="service_running">Сервіс вже запущений</string>
     <string name="open_folder">Відкрити папку</string>
     <string name="_default">за замовчуванням</string>
@@ -99,6 +100,7 @@
     <string name="low_memory">Закінчується пам\'ять на пристрої!</string>
     <string name="fix_permissions">Виправити</string>
     <string name="view_queue">Переглянути чергу</string>
+    <string name="clear_search_history">Очистити історію пошуку</string>
 
     <!-- Queue / Downloader -->
     <string name="downloader_title">Завантажувач</string>
@@ -732,6 +734,7 @@
     <string name="chapters_remove_failed">Не вдалося видалити глави</string>
     <string name="chapter_move_failed">Не вдалося перемістити главу</string>
     <string name="slideshow_start">Початок слайдшоу (затримка в <x:g id="time" example="0.5">%.1f</x:g> с)</string>
+    <string name="slideshow_start_vertical">Початок слайдшоу (<x:g example="швидко" id="speed">%s</x:g>)</string>
     <string name="slideshow_stop">Слайдшоу зупинено</string>
     <string name="ask_clear_chapters">Видалити всі глави?</string>
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -824,6 +824,11 @@
     <string name="title_startup_progress">Запускається…</string>
     <string name="title_startup_complete">Запуск завершено</string>
 
+    <!-- Missing WebView -->
+    <string name="missing_web_view_title">WebView не встановлено або вимкнено</string>
+    <string name="missing_web_view">Hentoid не виявив вбудований спеціальний браузер Android.\nНа жаль, додаток не може працювати без нього.\n\nШвидше за все, він насправді встановлений у вас, просто відключений: будь ласка, перейдіть в <b>Налаштування</b> &gt; <b>Додатки</b> &gt; <b>Відключені</b> та включіть <b>Android System WebView</b>.\n\nЯкщо ви не можете знайти такий додаток, будь ласка, встановіть його з <b><a href="https://play.google.com/store/apps/details?id=com.google.android.webview">Play Маркета</a></b>.</string>
+    <string name="missing_web_view_close">Закрити Hentoid</string>
+
     <!-- Group names -->
     <string name="group_today">Сьогодні</string>
     <string name="group_7">На тижні</string>

--- a/app/src/main/res/values-uk/strings_settings.xml
+++ b/app/src/main/res/values-uk/strings_settings.xml
@@ -162,11 +162,14 @@
     <string name="pref_viewer_page_turn_keyboard">Стрілки вліво/вправо на клавіатурі</string>
     <string name="pref_viewer_swipe_to_fling">Перегортати кілька сторінок одним свайпом</string>
     <string name="pref_viewer_invert_volume">Інвертувати кнопки гучності</string>
+    <string name="pref_viewer_book_switch">Перемикання книг</string>
+    <string name="pref_viewer_book_switch_volume">Кнопки гучності (довге натискання)</string>
     <string name="pref_viewer_zoom">Збільшення</string>
     <string name="pref_viewer_zoom_holding">Тимчасово збільшувати при утриманні пальця</string>
     <string name="pref_viewer_cap_tap_zoom">Обмежити зум за подвійним або довгим натисканням</string>
     <string name="pref_viewer_visuals">Зовнішній вигляд</string>
     <string name="pref_viewer_keep_screen_on">Не вимикати екран</string>
+    <string name="pref_viewer_display_notch">Показувати біля "чубчика"</string>
     <string name="pref_viewer_display_pagenum">Завжди показувати номер сторінки</string>
     <string name="pref_viewer_tap_transitions">Увімкнути анімацію зміни сторінок</string>
     <string name="pref_viewer_zoom_transitions">Увімкнути анімацію зуму</string>
@@ -188,5 +191,6 @@
     <string name="pref_viewer_continuous_summary_on">З останньої сторінки книги можна піти на наступну книгу</string>
     <string name="pref_viewer_read_threshold">Вважати книгу прочитаною після N сторінок</string>
     <string name="pref_viewer_slideshow_delay">Слайдшоу / Час показу кожної сторінки</string>
+    <string name="pref_viewer_slideshow_delay_vertical">Слайдшоу / Швидкість вертикального перегортання</string>
     <string name="doh_warning">Деякі сайти погано працюють з DNS через HTTPS. Скористайтеся стороннім додатком для DNS, якщо ви маєте проблеми при навігації (наприклад: порожні сторінки або помилки під час авторизації)</string>
 </resources>

--- a/app/src/main/res/values-uk/strings_settings.xml
+++ b/app/src/main/res/values-uk/strings_settings.xml
@@ -31,9 +31,9 @@
     <string name="pref_cat_downloads_folder">Бібліотека Hentoid</string>
     <string name="pref_select_folder_title">Вибір папки завантажень</string>
     <string name="pref_select_folder_summary">Виберіть, де Hentoid буде зберігати ваші завантаження</string>
-    <string name="pref_import_queue_empty_title">Додавати порожні книги в чергу як невдалі завантаження</string>
-    <string name="pref_import_queue_empty_on">Порожні книги будуть додані в чергу як помилки завантаження</string>
-    <string name="pref_import_queue_empty_off">Порожні книги будуть додані до бібліотеки</string>
+    <string name="pref_import_queue_empty_title">Додавати порожні імпортовані книги в чергу як невдалі завантаження</string>
+    <string name="pref_import_queue_empty_on">Порожні імпортовані книги будуть додані в чергу як помилки завантаження</string>
+    <string name="pref_import_queue_empty_off">Порожні імпортовані книги будуть додані до бібліотеки</string>
     <string name="pref_folder_naming_content_title">Назви папок</string>
     <string name="pref_folder_naming_content_summary">Спосіб найменування папок:\n<x:g id="convention" example="Назва - ID">%s</x:g></string>
     <string name="pref_import_running">Імпортування вже запущено</string>

--- a/app/src/main/res/values-uk/strings_tools.xml
+++ b/app/src/main/res/values-uk/strings_tools.xml
@@ -44,4 +44,9 @@
     <string name="tools_latest_logs_title">Логи додатка</string>
     <!-- Menu item description -->
     <string name="tools_latest_logs_summary">Переглянути останні логи додатка</string>
+    <string name="tools_import_empty_books_intro">Якщо не виявлено папки із зображеннями…</string>
+    <string name="tools_import_empty_books_entries_1">Не імпортувати</string>
+    <string name="tools_import_empty_books_entries_2">Імпортувати як порожню книгу</string>
+    <string name="tools_import_empty_books_entries_3">Імпортувати для стримінґу, якщо можливо</string>
+    <string name="tools_import_empty_books_entries_4">Додати до черги помилок</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -779,6 +779,11 @@
     <string name="title_startup_progress">Starting…</string>
     <string name="title_startup_complete">Startup complete</string>
 
+    <!-- Missing WebView -->
+    <string name="missing_web_view_title">WebView is not installed or disabled</string>
+    <string name="missing_web_view">Hentoid has been unable to find Android\'s Web Viewer.\nUnfortunately, the app cannot function without it.\n\nIt is most likely that it\'s actually installed on your system, but disabled: please go to <b>Settings</b> &gt; <b>Apps</b> &gt; <b>Disabled apps</b> and enable <b>Android System WebView</b>.\n\nIf you can\'t find the app, please install it from the <b><a href="https://play.google.com/store/apps/details?id=com.google.android.webview">Play Store</a></b>.</string>
+    <string name="missing_web_view_close">Close Hentoid</string>
+
     <!-- Group names -->
     <string name="group_today">Today</string>
     <string name="group_7">Last 7 days</string>


### PR DESCRIPTION
**Fixes issue** [#934](https://github.com/avluis/Hentoid/issues/934): Unhandled exception on app's startup when WebView is not available on the system
<br />

Summary of changes in this PR:

- Before any activity is even launched, `HentoidApp.java` tried to prefill user-agents by querying WebView; obviously, assuming it's present on the system and not disabled. It now throws an error into the log and ignores it, because a message will be shown to the user down the road.

- `SplashActivity` checks on its launch, whether WebView is available: if it's not, the launch halts and an error message is shown to the user instead with the explanation and advice.

Here's what the error screen looks like: 
![image](https://user-images.githubusercontent.com/11662482/174440039-7f329bc5-0b68-425d-80bc-350a5b95210d.png)

@AVnetWS/admin-team
