### PR TITLE
Fix some issues about English locale setting

### DIFF
--- a/app/src/main/java/me/devsaki/hentoid/activities/LibraryActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/LibraryActivity.java
@@ -15,8 +15,10 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.graphics.Typeface;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -60,6 +62,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import me.devsaki.hentoid.BuildConfig;
@@ -340,6 +343,20 @@ public class LibraryActivity extends BaseActivity {
             selectionToolbar.setNavigationOnClickListener(null);
         }
         super.onDestroy();
+    }
+
+    @Override
+    public void onRestart() {
+        // Change locale if set manually
+        if (Preferences.isForceEnglishLocale()) {
+            Locale englishLocale = new Locale("en");
+            Locale.setDefault(englishLocale);
+            Configuration config = getResources().getConfiguration();
+            config.setLocale(englishLocale);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) createConfigurationContext(config);
+            getResources().updateConfiguration(config, getResources().getDisplayMetrics());
+        }
+        super.onRestart();
     }
 
     private void onCreated() {

--- a/app/src/main/java/me/devsaki/hentoid/workers/BaseWorker.java
+++ b/app/src/main/java/me/devsaki/hentoid/workers/BaseWorker.java
@@ -1,6 +1,8 @@
 package me.devsaki.hentoid.workers;
 
 import android.content.Context;
+import android.content.res.Configuration;
+import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.IdRes;
@@ -19,10 +21,12 @@ import org.greenrobot.eventbus.EventBus;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import me.devsaki.hentoid.core.HentoidApp;
 import me.devsaki.hentoid.events.ServiceDestroyedEvent;
 import me.devsaki.hentoid.util.LogHelper;
+import me.devsaki.hentoid.util.Preferences;
 import me.devsaki.hentoid.util.notification.Notification;
 import me.devsaki.hentoid.util.notification.NotificationManager;
 import timber.log.Timber;
@@ -63,6 +67,16 @@ public abstract class BaseWorker extends Worker {
             String logName) {
         super(context, parameters);
         this.serviceId = serviceId;
+
+        // Change locale if set manually
+        if (Preferences.isForceEnglishLocale()) {
+            Locale englishLocale = new Locale("en");
+            Locale.setDefault(englishLocale);
+            Configuration config = context.getResources().getConfiguration();
+            config.setLocale(englishLocale);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) context.createConfigurationContext(config);
+            context.getResources().updateConfiguration(config, context.getResources().getDisplayMetrics());
+        }
 
         initNotifications(context);
 


### PR DESCRIPTION

**Fixes issue** : Fix some issues about English locale setting
<br />

Summary of changes in this PR:

- Make notification to English when English locale setting is on

- Make sure LibraryActivity to English when English locale setting is on

Additional commit notes for project team:

- Notifications and Toasts generated by BaseWorker are affected by machine's locale, NOT an app's setting.
e.g) download progress notification, "Already queued" toast.

- Sometimes the app changes its locale to machine's locale. _e.g) initWebview of BaseWebActivity.java line:270_
It affects to LibraryActivity's locale when onRestart LibraryActivity.
e.g) visit website -> back to LibraryActivity

- LibraryActivity is the only "singleTop" activity. So I override LibraryActivity's onRestart only.

<br />
@AVnetWS/admin-team
