### PR TITLE
Optimize performance of changing locale to English

### DIFF
--- a/app/src/main/java/me/devsaki/hentoid/activities/BaseActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/BaseActivity.java
@@ -39,13 +39,16 @@ public abstract class BaseActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         // Change locale if set manually
         if (Preferences.isForceEnglishLocale()) {
-            Locale englishLocale = new Locale("en");
-            Locale.setDefault(englishLocale);
             Configuration config = getResources().getConfiguration();
-            config.setLocale(englishLocale);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) createConfigurationContext(config);
-            getResources().updateConfiguration(config, getResources().getDisplayMetrics());
+            if (!config.locale.equals(Locale.ENGLISH)) {
+                Locale englishLocale = new Locale("en");
+                Locale.setDefault(englishLocale);
+                config.setLocale(englishLocale);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) createConfigurationContext(config);
+                getResources().updateConfiguration(config, getResources().getDisplayMetrics());
+            }
         }
+
         ThemeHelper.applyTheme(this);
         if (!EventBus.getDefault().isRegistered(this)) EventBus.getDefault().register(this);
     }

--- a/app/src/main/java/me/devsaki/hentoid/activities/BaseActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/BaseActivity.java
@@ -1,8 +1,6 @@
 package me.devsaki.hentoid.activities;
 
 import android.content.Intent;
-import android.content.res.Configuration;
-import android.os.Build;
 import android.os.Bundle;
 
 import androidx.annotation.ContentView;
@@ -14,10 +12,9 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.threeten.bp.Instant;
 
-import java.util.Locale;
-
 import me.devsaki.hentoid.core.HentoidApp;
 import me.devsaki.hentoid.events.CommunicationEvent;
+import me.devsaki.hentoid.util.LocaleHelper;
 import me.devsaki.hentoid.util.Preferences;
 import me.devsaki.hentoid.util.ThemeHelper;
 import me.devsaki.hentoid.util.ToastHelper;
@@ -38,16 +35,7 @@ public abstract class BaseActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         // Change locale if set manually
-        if (Preferences.isForceEnglishLocale()) {
-            Configuration config = getResources().getConfiguration();
-            if (!config.locale.equals(Locale.ENGLISH)) {
-                Locale englishLocale = new Locale("en");
-                Locale.setDefault(englishLocale);
-                config.setLocale(englishLocale);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) createConfigurationContext(config);
-                getResources().updateConfiguration(config, getResources().getDisplayMetrics());
-            }
-        }
+        LocaleHelper.convertLocaleToEnglish(this);
 
         ThemeHelper.applyTheme(this);
         if (!EventBus.getDefault().isRegistered(this)) EventBus.getDefault().register(this);

--- a/app/src/main/java/me/devsaki/hentoid/activities/LibraryActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/LibraryActivity.java
@@ -15,10 +15,8 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
-import android.content.res.Configuration;
 import android.graphics.Typeface;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -62,7 +60,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import me.devsaki.hentoid.BuildConfig;
@@ -87,12 +84,13 @@ import me.devsaki.hentoid.notification.archive.ArchiveNotificationChannel;
 import me.devsaki.hentoid.notification.archive.ArchiveProgressNotification;
 import me.devsaki.hentoid.notification.archive.ArchiveStartNotification;
 import me.devsaki.hentoid.util.ContentHelper;
-import me.devsaki.hentoid.util.file.FileHelper;
 import me.devsaki.hentoid.util.Helper;
-import me.devsaki.hentoid.util.file.PermissionHelper;
+import me.devsaki.hentoid.util.LocaleHelper;
 import me.devsaki.hentoid.util.Preferences;
 import me.devsaki.hentoid.util.SearchHelper;
 import me.devsaki.hentoid.util.TooltipHelper;
+import me.devsaki.hentoid.util.file.FileHelper;
+import me.devsaki.hentoid.util.file.PermissionHelper;
 import me.devsaki.hentoid.util.notification.NotificationManager;
 import me.devsaki.hentoid.viewmodels.LibraryViewModel;
 import me.devsaki.hentoid.viewmodels.ViewModelFactory;
@@ -348,16 +346,8 @@ public class LibraryActivity extends BaseActivity {
     @Override
     public void onRestart() {
         // Change locale if set manually
-        if (Preferences.isForceEnglishLocale()) {
-            Configuration config = getResources().getConfiguration();
-            if (!config.locale.equals(Locale.ENGLISH)) {
-                Locale englishLocale = new Locale("en");
-                Locale.setDefault(englishLocale);
-                config.setLocale(englishLocale);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) createConfigurationContext(config);
-                getResources().updateConfiguration(config, getResources().getDisplayMetrics());
-            }
-        }
+        LocaleHelper.convertLocaleToEnglish(this);
+
         super.onRestart();
     }
 

--- a/app/src/main/java/me/devsaki/hentoid/activities/LibraryActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/LibraryActivity.java
@@ -349,12 +349,14 @@ public class LibraryActivity extends BaseActivity {
     public void onRestart() {
         // Change locale if set manually
         if (Preferences.isForceEnglishLocale()) {
-            Locale englishLocale = new Locale("en");
-            Locale.setDefault(englishLocale);
             Configuration config = getResources().getConfiguration();
-            config.setLocale(englishLocale);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) createConfigurationContext(config);
-            getResources().updateConfiguration(config, getResources().getDisplayMetrics());
+            if (!config.locale.equals(Locale.ENGLISH)) {
+                Locale englishLocale = new Locale("en");
+                Locale.setDefault(englishLocale);
+                config.setLocale(englishLocale);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) createConfigurationContext(config);
+                getResources().updateConfiguration(config, getResources().getDisplayMetrics());
+            }
         }
         super.onRestart();
     }

--- a/app/src/main/java/me/devsaki/hentoid/util/LocaleHelper.java
+++ b/app/src/main/java/me/devsaki/hentoid/util/LocaleHelper.java
@@ -1,0 +1,23 @@
+package me.devsaki.hentoid.util;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.os.Build;
+
+import java.util.Locale;
+
+public class LocaleHelper {
+    public static void convertLocaleToEnglish(Context context) {
+        if (Preferences.isForceEnglishLocale()) {
+            Configuration config = context.getResources().getConfiguration();
+            if (!config.locale.equals(Locale.ENGLISH)) {
+                Locale englishLocale = new Locale("en");
+                Locale.setDefault(englishLocale);
+                config.setLocale(englishLocale);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+                    context.createConfigurationContext(config);
+                context.getResources().updateConfiguration(config, context.getResources().getDisplayMetrics());
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/devsaki/hentoid/workers/BaseWorker.java
+++ b/app/src/main/java/me/devsaki/hentoid/workers/BaseWorker.java
@@ -70,12 +70,14 @@ public abstract class BaseWorker extends Worker {
 
         // Change locale if set manually
         if (Preferences.isForceEnglishLocale()) {
-            Locale englishLocale = new Locale("en");
-            Locale.setDefault(englishLocale);
             Configuration config = context.getResources().getConfiguration();
-            config.setLocale(englishLocale);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) context.createConfigurationContext(config);
-            context.getResources().updateConfiguration(config, context.getResources().getDisplayMetrics());
+            if (!config.locale.equals(Locale.ENGLISH)) {
+                Locale englishLocale = new Locale("en");
+                Locale.setDefault(englishLocale);
+                config.setLocale(englishLocale);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) context.createConfigurationContext(config);
+                context.getResources().updateConfiguration(config, context.getResources().getDisplayMetrics());
+            }
         }
 
         initNotifications(context);

--- a/app/src/main/java/me/devsaki/hentoid/workers/BaseWorker.java
+++ b/app/src/main/java/me/devsaki/hentoid/workers/BaseWorker.java
@@ -1,8 +1,6 @@
 package me.devsaki.hentoid.workers;
 
 import android.content.Context;
-import android.content.res.Configuration;
-import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.IdRes;
@@ -21,12 +19,11 @@ import org.greenrobot.eventbus.EventBus;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 import me.devsaki.hentoid.core.HentoidApp;
 import me.devsaki.hentoid.events.ServiceDestroyedEvent;
+import me.devsaki.hentoid.util.LocaleHelper;
 import me.devsaki.hentoid.util.LogHelper;
-import me.devsaki.hentoid.util.Preferences;
 import me.devsaki.hentoid.util.notification.Notification;
 import me.devsaki.hentoid.util.notification.NotificationManager;
 import timber.log.Timber;
@@ -69,16 +66,7 @@ public abstract class BaseWorker extends Worker {
         this.serviceId = serviceId;
 
         // Change locale if set manually
-        if (Preferences.isForceEnglishLocale()) {
-            Configuration config = context.getResources().getConfiguration();
-            if (!config.locale.equals(Locale.ENGLISH)) {
-                Locale englishLocale = new Locale("en");
-                Locale.setDefault(englishLocale);
-                config.setLocale(englishLocale);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) context.createConfigurationContext(config);
-                context.getResources().updateConfiguration(config, context.getResources().getDisplayMetrics());
-            }
-        }
+        LocaleHelper.convertLocaleToEnglish(context);
 
         initNotifications(context);
 


### PR DESCRIPTION

**Fixes issue** : Optimize performance of changing locale to English
<br />

Summary of changes in this PR:

- Optimize performance of changing locale to English

Additional commit notes for project team:

- There's two case before doing "changing locale"
Case 1. The app locale is already "en"
Case 2. The app locale is not "en"

- I checked the ratio of "Case 1" is pretty higher than "Case 2" before doing "changing locale"

- Optimizing idea is the app don't need to change locale if its locale is already "en"

<br />
@AVnetWS/admin-team
