### PR TITLE
Mark merged books in browsers

### DIFF
--- a/app/src/main/assets/downloaded.css
+++ b/app/src/main/assets/downloaded.css
@@ -21,3 +21,27 @@
   background-repeat: no-repeat;
   z-index:11;
 }
+
+/* Custom styles to mark merged books */
+.watermarked-merged {
+
+}
+
+.watermarked-merged img {
+  filter: grayscale(100%) opacity(25%);
+}
+
+.watermarked-merged:after {
+  content: "";
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  background-image: url("https://bogus.com/hentoid-mergedmark.webp");
+  background-size: 75px 75px;
+  background-position: 50% 50%;
+  background-repeat: no-repeat;
+  z-index:11;
+}

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/BaseWebActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/BaseWebActivity.java
@@ -1453,7 +1453,7 @@ public abstract class BaseWebActivity extends BaseActivity implements CustomWebV
     public String getCustomCss() {
         if (null == customCss) {
             StringBuilder sb = new StringBuilder();
-            if (Preferences.isBrowserMarkDownloaded())
+            if (Preferences.isBrowserMarkDownloaded() || Preferences.isBrowserMarkMerged())
                 FileHelper.getAssetAsString(getAssets(), "downloaded.css", sb);
             if (getStartSite().equals(Site.NHENTAI) && Preferences.isBrowserNhentaiInvisibleBlacklist())
                 FileHelper.getAssetAsString(getAssets(), "nhentai_invisible_blacklist.css", sb);

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/BaseWebActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/BaseWebActivity.java
@@ -1304,6 +1304,8 @@ public abstract class BaseWebActivity extends BaseActivity implements CustomWebV
             mergedBooksUrls.clear();
             mergedBooksUrls.addAll(
                     Stream.of(dao.selectAllMergedUrls(getStartSite()))
+                            .map(s -> s.replace(getStartSite().getUrl(), ""))
+                            .map(s -> s.replaceAll("\\b|/galleries|/gallery|/g|/entry\\b", "")) //each sites "gallery" path
                             .map(s -> s.replaceAll("\\p{Punct}", "."))
                             .map(s -> s.endsWith(".") && s.length() > 1 ? s.substring(0, s.length() - 1) : s)
                             .toList()

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/CustomWebViewClient.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/CustomWebViewClient.java
@@ -750,7 +750,7 @@ class CustomWebViewClient extends WebViewClient {
             }
 
             // Mark downloaded books and merged books
-            if (siteUrls != null && mergedSiteUrls != null && !siteUrls.isEmpty()) {
+            if (siteUrls != null && mergedSiteUrls != null && (!siteUrls.isEmpty() || !mergedSiteUrls.isEmpty())) {
                 // Format elements
                 Elements plainLinks = doc.select("a");
                 Elements linkedImages = doc.select("a img");

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/CustomWebViewClient.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/CustomWebViewClient.java
@@ -84,9 +84,11 @@ class CustomWebViewClient extends WebViewClient {
     // Pre-built object to represent an empty input stream
     // (will be used instead of the actual stream when the requested resource is blocked)
     private final byte[] nothing = "".getBytes();
-    // Pre-built object to represent WEBP binary data for the checkmark icon used to mark downloaded boks
+    // Pre-built object to represent WEBP binary data for the checkmark icon used to mark downloaded books
     // (will be fed directly to the browser when the resourcei is requested)
     private final byte[] checkmark;
+    // this is for merged books
+    private final byte[] mergedMark;
 
     // Site for the session
     protected final Site site;
@@ -114,6 +116,7 @@ class CustomWebViewClient extends WebViewClient {
 
     // Faster access to Preferences settings
     private final AtomicBoolean markDownloaded = new AtomicBoolean(Preferences.isBrowserMarkDownloaded());
+    private final AtomicBoolean markMerged = new AtomicBoolean((Preferences.isBrowserMarkMerged()));
     private final AtomicBoolean dnsOverHttpsEnabled = new AtomicBoolean(Preferences.getDnsOverHttps() > -1);
 
     // Disposable to be used for punctual operations
@@ -149,6 +152,13 @@ class CustomWebViewClient extends WebViewClient {
         checkmark = ImageHelper.BitmapToWebp(
                 ImageHelper.tintBitmap(
                         ImageHelper.getBitmapFromVectorDrawable(HentoidApp.getInstance(), R.drawable.ic_checked),
+                        HentoidApp.getInstance().getResources().getColor(R.color.secondary_light)
+                )
+        );
+
+        mergedMark = ImageHelper.BitmapToWebp(
+                ImageHelper.tintBitmap(
+                        ImageHelper.getBitmapFromVectorDrawable(HentoidApp.getInstance(), R.drawable.ic_action_merge),
                         HentoidApp.getInstance().getResources().getColor(R.color.secondary_light)
                 )
         );
@@ -420,6 +430,8 @@ class CustomWebViewClient extends WebViewClient {
             return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream(nothing));
         } else if (isMarkDownloaded() && url.contains("hentoid-checkmark")) {
             return new WebResourceResponse(ImageHelper.MIME_IMAGE_WEBP, "utf-8", new ByteArrayInputStream(checkmark));
+        } else if (isMarkMerged() && url.contains("hentoid-mergedmark")) {
+            return new WebResourceResponse(ImageHelper.MIME_IMAGE_WEBP, "utf-8", new ByteArrayInputStream(mergedMark));
         } else {
             if (isGalleryPage(url)) return parseResponse(url, headers, true, false);
             else if (BuildConfig.DEBUG) Timber.v("WebView : not gallery %s", url);
@@ -552,8 +564,8 @@ class CustomWebViewClient extends WebViewClient {
 
                 // Remove dirty elements from HTML resources
                 String customCss = activity.getCustomCss();
-                if (removableElements != null || hideableElements != null || jsContentBlacklist != null || isMarkDownloaded() || !customCss.isEmpty()) {
-                    browserStream = ProcessHtml(browserStream, urlStr, customCss, removableElements, hideableElements, jsContentBlacklist, activity.getAllSiteUrls());
+                if (removableElements != null || hideableElements != null || jsContentBlacklist != null || isMarkDownloaded() || isMarkMerged() || !customCss.isEmpty()) {
+                    browserStream = ProcessHtml(browserStream, urlStr, customCss, removableElements, hideableElements, jsContentBlacklist, activity.getAllSiteUrls(), activity.getAllMergedBooksUrls());
                     if (null == browserStream) return null;
                 }
 
@@ -648,6 +660,14 @@ class CustomWebViewClient extends WebViewClient {
         markDownloaded.set(value);
     }
 
+    boolean isMarkMerged() {
+        return markMerged.get();
+    }
+
+    void setMarkMerged(boolean value) {
+        markMerged.set(value);
+    }
+
     void setDnsOverHttpsEnabled(boolean value) {
         dnsOverHttpsEnabled.set(value);
     }
@@ -675,6 +695,7 @@ class CustomWebViewClient extends WebViewClient {
      * @param hideableElements   CSS selectors of the nodes to hide
      * @param jsContentBlacklist Blacklisted elements to detect script tags to remove
      * @param siteUrls           Urls of the covers or links to visually mark as downloaded
+     * @param mergedSiteUrls     Urls of the covers or links to visually mark as merged
      * @return Stream containing the HTML document stripped from the elements to remove
      */
     @Nullable
@@ -685,7 +706,8 @@ class CustomWebViewClient extends WebViewClient {
             @Nullable List<String> removableElements,
             @Nullable List<String> hideableElements,
             @Nullable List<String> jsContentBlacklist,
-            @Nullable List<String> siteUrls) {
+            @Nullable List<String> siteUrls,
+            @Nullable List<String> mergedSiteUrls) {
         try {
             Document doc = Jsoup.parse(stream, null, baseUri);
 
@@ -727,8 +749,8 @@ class CustomWebViewClient extends WebViewClient {
                 }
             }
 
-            // Mark downloaded books
-            if (siteUrls != null && !siteUrls.isEmpty()) {
+            // Mark downloaded books and merged books
+            if (siteUrls != null && mergedSiteUrls != null && !siteUrls.isEmpty()) {
                 // Format elements
                 Elements plainLinks = doc.select("a");
                 Elements linkedImages = doc.select("a img");
@@ -767,6 +789,20 @@ class CustomWebViewClient extends WebViewClient {
                                 markedElement = entry.getValue().first;
                             }
                             markedElement.addClass("watermarked");
+                            break;
+                        }
+                    }
+                    for (String url : mergedSiteUrls) {
+                        if (entry.getKey().endsWith(url)) {
+                            Element markedElement = entry.getValue().second; // Linked images have priority over plain links
+                            if (markedElement != null) { // Mark two levels above the image
+                                Element imgParent = markedElement.parent();
+                                if (imgParent != null) imgParent = imgParent.parent();
+                                if (imgParent != null) markedElement = imgParent;
+                            } else { // Mark plain link
+                                markedElement = entry.getValue().first;
+                            }
+                            markedElement.addClass("watermarked-merged");
                             break;
                         }
                     }
@@ -812,6 +848,7 @@ class CustomWebViewClient extends WebViewClient {
 
         // GETTERS
         List<String> getAllSiteUrls();
+        List<String> getAllMergedBooksUrls();
 
         String getCustomCss();
     }

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/CustomWebViewClient.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/CustomWebViewClient.java
@@ -438,7 +438,7 @@ class CustomWebViewClient extends WebViewClient {
 
             // If we're here to remove "dirty elements" or mark downloaded books, we only do it
             // on HTML resources (URLs without extension) from the source's main domain
-            if ((removableElements != null || hideableElements != null || jsContentBlacklist != null || isMarkDownloaded() || !activity.getCustomCss().isEmpty())
+            if ((removableElements != null || hideableElements != null || jsContentBlacklist != null || isMarkDownloaded() || isMarkMerged() || !activity.getCustomCss().isEmpty())
                     && (HttpHelper.getExtensionFromUri(url).isEmpty() || HttpHelper.getExtensionFromUri(url).equalsIgnoreCase("html"))) {
                 String host = Uri.parse(url).getHost();
                 if (host != null && !isHostNotInRestrictedDomains(host))

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/EHentaiActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/EHentaiActivity.java
@@ -65,7 +65,7 @@ public class EHentaiActivity extends BaseWebActivity {
                 );
             }
 
-            if (isMarkDownloaded())
+            if (isMarkDownloaded() || isMarkMerged())
                 return super.parseResponse(urlStr, requestHeaders, false, false); // Rewrite HTML
             else return null;
         }

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/ExHentaiActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/ExHentaiActivity.java
@@ -111,7 +111,7 @@ public class ExHentaiActivity extends BaseWebActivity {
                 );
             }
 
-            if (isMarkDownloaded())
+            if (isMarkDownloaded() || isMarkMerged())
                 return super.parseResponse(urlStr, requestHeaders, false, false); // Rewrite HTML
             else return null;
         }

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/HitomiActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/HitomiActivity.java
@@ -78,7 +78,7 @@ public class HitomiActivity extends BaseWebActivity {
         public WebResourceResponse shouldInterceptRequest(@NonNull WebView view, @NonNull WebResourceRequest request) {
             String url = request.getUrl().toString();
 
-            if (isMarkDownloaded() && url.contains("galleryblock")) { // Process book blocks to mark existing ones
+            if ((isMarkDownloaded() ||isMarkMerged()) && url.contains("galleryblock")) { // Process book blocks to mark existing ones
                 WebResourceResponse result = parseResponse(url, request.getRequestHeaders(), false, false);
                 if (result != null) return result;
                 else return sendRequest(request);

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/HitomiActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/HitomiActivity.java
@@ -78,7 +78,7 @@ public class HitomiActivity extends BaseWebActivity {
         public WebResourceResponse shouldInterceptRequest(@NonNull WebView view, @NonNull WebResourceRequest request) {
             String url = request.getUrl().toString();
 
-            if ((isMarkDownloaded() ||isMarkMerged()) && url.contains("galleryblock")) { // Process book blocks to mark existing ones
+            if ((isMarkDownloaded() || isMarkMerged()) && url.contains("galleryblock")) { // Process book blocks to mark existing ones
                 WebResourceResponse result = parseResponse(url, request.getRequestHeaders(), false, false);
                 if (result != null) return result;
                 else return sendRequest(request);

--- a/app/src/main/java/me/devsaki/hentoid/database/CollectionDAO.java
+++ b/app/src/main/java/me/devsaki/hentoid/database/CollectionDAO.java
@@ -57,6 +57,8 @@ public interface CollectionDAO {
 
     Set<String> selectAllSourceUrls(@NonNull Site site);
 
+    Set<String> selectAllMergedUrls(@NonNull Site site);
+
     List<Content> searchTitlesWith(@NonNull final String word, int[] contentStatusCodes);
 
     long insertContent(@NonNull final Content content);

--- a/app/src/main/java/me/devsaki/hentoid/database/ObjectBoxDAO.java
+++ b/app/src/main/java/me/devsaki/hentoid/database/ObjectBoxDAO.java
@@ -298,6 +298,10 @@ public class ObjectBoxDAO implements CollectionDAO {
         return db.selectAllContentUrls(site.getCode());
     }
 
+    public Set<String> selectAllMergedUrls(@NonNull Site site){
+        return db.selectAllMergedContentUrls(site);
+    }
+
     @Override
     public List<Content> searchTitlesWith(@NonNull String word, int[] contentStatusCodes) {
         return db.selectContentWithTitle(word, contentStatusCodes);

--- a/app/src/main/java/me/devsaki/hentoid/database/ObjectBoxDB.java
+++ b/app/src/main/java/me/devsaki/hentoid/database/ObjectBoxDB.java
@@ -427,13 +427,8 @@ public class ObjectBoxDB {
     }
 
     Set<String> selectAllMergedContentUrls(Site site) {
-        Query<Chapter> allChapterQ = store.boxFor(Chapter.class).query().build();
-
-        return new HashSet<>(Stream.of(allChapterQ.property(Chapter_.url).findStrings())
-                .filter(s -> s.contains(site.getUrl()))
-                .map(s -> s.replace(site.getUrl(), ""))
-                .map(s -> s.replaceAll("\\b|/galleries|/gallery|/g|/entry\\b", "")) //each sites "gallery" path
-                .toList());
+        Query<Chapter> allChapterQ = store.boxFor(Chapter.class).query().startsWith(Chapter_.url,site.getUrl(), QueryBuilder.StringOrder.CASE_SENSITIVE).build();
+        return new HashSet<>(Stream.of(allChapterQ.property(Chapter_.url).findStrings()).toList());
     }
 
     @Nullable

--- a/app/src/main/java/me/devsaki/hentoid/database/ObjectBoxDB.java
+++ b/app/src/main/java/me/devsaki/hentoid/database/ObjectBoxDB.java
@@ -427,7 +427,7 @@ public class ObjectBoxDB {
     }
 
     Set<String> selectAllMergedContentUrls(Site site) {
-        Query<Chapter> allChapterQ = store.boxFor(Chapter.class).query().startsWith(Chapter_.url,site.getUrl(), QueryBuilder.StringOrder.CASE_SENSITIVE).build();
+        Query<Chapter> allChapterQ = store.boxFor(Chapter.class).query().startsWith(Chapter_.url,site.getUrl(), QueryBuilder.StringOrder.CASE_INSENSITIVE).build();
         return new HashSet<>(Stream.of(allChapterQ.property(Chapter_.url).findStrings()).toList());
     }
 

--- a/app/src/main/java/me/devsaki/hentoid/database/ObjectBoxDB.java
+++ b/app/src/main/java/me/devsaki/hentoid/database/ObjectBoxDB.java
@@ -426,6 +426,16 @@ public class ObjectBoxDB {
         return new HashSet<>(Stream.of(allContentQ.property(Content_.url).findStrings()).toList());
     }
 
+    Set<String> selectAllMergedContentUrls(Site site) {
+        Query<Chapter> allChapterQ = store.boxFor(Chapter.class).query().build();
+
+        return new HashSet<>(Stream.of(allChapterQ.property(Chapter_.url).findStrings())
+                .filter(s -> s.contains(site.getUrl()))
+                .map(s -> s.replace(site.getUrl(), ""))
+                .map(s -> s.replaceAll("\\b|/galleries|/gallery|/g|/entry\\b", "")) //each sites "gallery" path
+                .toList());
+    }
+
     @Nullable
     Content selectContentEndWithStorageUri(@NonNull final String folderUriEnd, boolean onlyFlagged) {
         QueryBuilder<Content> queryBuilder = store.boxFor(Content.class).query().endsWith(Content_.storageUri, folderUriEnd, QueryBuilder.StringOrder.CASE_INSENSITIVE);

--- a/app/src/main/java/me/devsaki/hentoid/util/Preferences.java
+++ b/app/src/main/java/me/devsaki/hentoid/util/Preferences.java
@@ -390,6 +390,10 @@ public final class Preferences {
         return sharedPreferences.getBoolean(Key.BROWSER_MARK_DOWNLOADED, Default.BROWSER_MARK_DOWNLOADED);
     }
 
+    public static boolean isBrowserMarkMerged() {
+        return sharedPreferences.getBoolean(Key.BROWSER_MARK_MERGED, Default.BROWSER_MARK_DOWNLOADED);
+    }
+
     public static int getBrowserDlAction() {
         return Integer.parseInt(
                 sharedPreferences.getString(
@@ -895,6 +899,7 @@ public final class Preferences {
         static final String BROWSER_RESUME_LAST = "pref_browser_resume_last";
         static final String BROWSER_AUGMENTED = "pref_browser_augmented";
         public static final String BROWSER_MARK_DOWNLOADED = "browser_mark_downloaded";
+        public static final String BROWSER_MARK_MERGED = "browser_mark_merged";
         public static final String BROWSER_DL_ACTION = "pref_browser_dl_action";
         public static final String BROWSER_QUICK_DL = "pref_browser_quick_dl";
         public static final String BROWSER_QUICK_DL_THRESHOLD = "pref_browser_quick_dl_threshold";

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -423,6 +423,7 @@
     <string name="pref_browser_duplicate_ask_default" translatable="false">true</string>
     <string name="pref_browser_duplicate_try_pages_default" translatable="false">true</string>
     <string name="pref_browser_mark_downloaded_default" translatable="false">false</string>
+    <string name="pref_browser_mark_merged_default" translatable="false">false</string>
     <string name="pref_browser_override_overview_default" translatable="false">false</string>
     <string name="pref_browser_initial_zoom_default" translatable="false">20</string>
     <string name="pref_browser_dns_default" translatable="false">-1</string>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -88,6 +88,9 @@
     <string name="pref_browser_mark_downloaded_title">Mark downloaded books</string>
     <string name="pref_browser_mark_downloaded_off">Downloaded books have no special display</string>
     <string name="pref_browser_mark_downloaded_on">Downloaded books are marked\nNB: does not work on all sites</string>
+    <string name="pref_browser_mark_merged_title">Mark merged books</string>
+    <string name="pref_browser_mark_merged_off">Merged books have no special display</string>
+    <string name="pref_browser_mark_merged_on">Merged books are marked\nNB: does not work on all sites</string>
     <string name="pref_browser_visuals">Visuals</string>
     <string name="pref_browser_augmented_title">Augmented browser</string>
     <string name="pref_browser_augmented_off">Using vanilla behaviour</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -252,6 +252,13 @@
                 android:title="@string/pref_browser_mark_downloaded_title"
                 app:iconSpaceReserved="false" />
             <CheckBoxPreference
+                android:defaultValue="@string/pref_browser_mark_merged_default"
+                android:key="browser_mark_merged"
+                android:summaryOff="@string/pref_browser_mark_merged_off"
+                android:summaryOn="@string/pref_browser_mark_merged_on"
+                android:title="@string/pref_browser_mark_merged_title"
+                app:iconSpaceReserved="false" />
+            <CheckBoxPreference
                 android:defaultValue="@string/pref_browser_nhentai_invisible_blacklist_default"
                 android:key="pref_nhentai_invisible_blacklist"
                 android:summaryOff="@string/pref_browser_nhentai_invisible_blacklist_off"


### PR DESCRIPTION
**Implements Feature:** Mark merged books in browser
<br />

Summary of changes in this PR:

- New feature to mark merged books in browser.

- Work like "Mark downloaded books" but display "merged" icon on the image.

Additional commit notes for project team:

- If user merges "book A" and "book B", only book A is marked as downloaded in browser.
This new feature make "book B" also marked as merged so users can notice this book is in merged book.

- "Book A" also marked as merged, not downloaded.


<br />
@AVnetWS/admin-team
