### PR TITLE
Duplicate detector : Show how many items are left in main page

### DIFF
--- a/app/src/main/java/me/devsaki/hentoid/activities/DuplicateDetectorActivity.kt
+++ b/app/src/main/java/me/devsaki/hentoid/activities/DuplicateDetectorActivity.kt
@@ -76,7 +76,8 @@ class DuplicateDetectorActivity : BaseActivity() {
                 enableCurrentFragment()
                 hideSettingsBar()
                 updateToolbar(0, 0, 0)
-                viewModel.allDuplicates.observe(this@DuplicateDetectorActivity, { updateTitle(it.size * -1) })
+                viewModel.allDuplicates.observe(this@DuplicateDetectorActivity,
+                        { updateTitle(it.groupBy { it.referenceContent }.mapValues { it.value.sumOf { 1 as Int } }.size * -1) })
                 updateSelectionToolbar()
             }
         })

--- a/app/src/main/java/me/devsaki/hentoid/activities/DuplicateDetectorActivity.kt
+++ b/app/src/main/java/me/devsaki/hentoid/activities/DuplicateDetectorActivity.kt
@@ -76,7 +76,7 @@ class DuplicateDetectorActivity : BaseActivity() {
                 enableCurrentFragment()
                 hideSettingsBar()
                 updateToolbar(0, 0, 0)
-                updateTitle(-1)
+                updateTitle(if (viewModel.allDuplicates.value != null) viewModel.allDuplicates.value!!.size * -1 else 0)
                 updateSelectionToolbar()
             }
         })
@@ -133,10 +133,14 @@ class DuplicateDetectorActivity : BaseActivity() {
     }
 
     fun updateTitle(count: Int) {
-        binding!!.toolbar.title = if (count > -1) resources.getQuantityString(
+        binding!!.toolbar.title = if (count > 0) resources.getQuantityString(
             R.plurals.duplicate_detail_title,
             count,
             count
+        ) else if (count < 0) resources.getQuantityString(
+            R.plurals.duplicate_main_title,
+            -count,
+            -count
         ) else resources.getString(R.string.title_activity_duplicate_detector)
     }
 

--- a/app/src/main/java/me/devsaki/hentoid/activities/DuplicateDetectorActivity.kt
+++ b/app/src/main/java/me/devsaki/hentoid/activities/DuplicateDetectorActivity.kt
@@ -76,7 +76,7 @@ class DuplicateDetectorActivity : BaseActivity() {
                 enableCurrentFragment()
                 hideSettingsBar()
                 updateToolbar(0, 0, 0)
-                updateTitle(if (viewModel.allDuplicates.value != null) viewModel.allDuplicates.value!!.size * -1 else 0)
+                viewModel.allDuplicates.observe(this@DuplicateDetectorActivity, { updateTitle(it.size * -1) })
                 updateSelectionToolbar()
             }
         })
@@ -132,6 +132,15 @@ class DuplicateDetectorActivity : BaseActivity() {
         )
     }
 
+    /**
+     * Update the title of the DuplicateDetectorActivity
+     * ```
+     * if count>0, update the title to "n duplicates" for the detail page
+     * if count<0, update the title to "n item(s) left" for the main page
+     * if count=0, update the title to "Duplicate Detector" for the main page without any items
+     * ```
+     * @param count Number of items
+     */
     fun updateTitle(count: Int) {
         binding!!.toolbar.title = if (count > 0) resources.getQuantityString(
             R.plurals.duplicate_detail_title,

--- a/app/src/main/java/me/devsaki/hentoid/fragments/tools/DuplicateMainFragment.kt
+++ b/app/src/main/java/me/devsaki/hentoid/fragments/tools/DuplicateMainFragment.kt
@@ -262,8 +262,6 @@ class DuplicateMainFragment : Fragment(R.layout.fragment_duplicate_main) {
     private fun onDuplicatesChanged(duplicates: List<DuplicateEntry>) {
         Timber.i(">> New duplicates ! Size=%s", duplicates.size)
 
-        activity.get()?.updateTitle(duplicates.size * -1)
-
         // Update settings panel visibility
         if (duplicates.isEmpty()) {
             binding.emptyTxt.visibility = View.VISIBLE

--- a/app/src/main/java/me/devsaki/hentoid/fragments/tools/DuplicateMainFragment.kt
+++ b/app/src/main/java/me/devsaki/hentoid/fragments/tools/DuplicateMainFragment.kt
@@ -262,6 +262,8 @@ class DuplicateMainFragment : Fragment(R.layout.fragment_duplicate_main) {
     private fun onDuplicatesChanged(duplicates: List<DuplicateEntry>) {
         Timber.i(">> New duplicates ! Size=%s", duplicates.size)
 
+        activity.get()?.updateTitle(duplicates.size * -1)
+
         // Update settings panel visibility
         if (duplicates.isEmpty()) {
             binding.emptyTxt.visibility = View.VISIBLE

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -792,6 +792,10 @@
     </plurals>
     <string name="duplicate_empty_first_use">Nothing to display - Run a new duplicate search</string>
     <string name="duplicate_processing">Detecting duplicates…</string>
+    <plurals name="duplicate_main_title">
+        <item quantity="one"><x:g example="1" id="number">%d</x:g> item left</item>
+        <item quantity="other"><x:g example="2" id="number">%d</x:g> items left</item>
+    </plurals>
     <plurals name="duplicate_detail_title">
         <item quantity="one"><x:g example="1" id="number">%d</x:g> duplicate</item>
         <item quantity="other"><x:g example="2" id="number">%d</x:g> duplicates</item>


### PR DESCRIPTION
**Implements Feature:** Show how many items are left in main page of a duplicate detector.

<br />

Summary of changes in this PR:

- Show how many items are left in main page of a duplicate detector.

Additional commit notes for project team:

- `DuplicateDetectorActivity.updateTitle` has parameter `count`
if count>0, `updateTitle` update title to "n duplicates" for the detail page
if count<0, `updateTitle` update title to "n item(s) left" for the main page
if count=0, `updateTitle` update title to "Duplicate Detector" for the main page without any items

<br />
@AVnetWS/admin-team
