### PR TITLE
Duplicate detector : Fix to display a right number of items in the detail page

### DIFF
--- a/app/src/main/java/me/devsaki/hentoid/activities/DuplicateDetectorActivity.kt
+++ b/app/src/main/java/me/devsaki/hentoid/activities/DuplicateDetectorActivity.kt
@@ -59,6 +59,11 @@ class DuplicateDetectorActivity : BaseActivity() {
         initSelectionToolbar()
     }
 
+    override fun onPause() {
+        super.onPause()
+        viewModel.allDuplicates.removeObservers(this)
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         binding = null


### PR DESCRIPTION
**Fixes issue** : Fix to display a right number of items in the detail page of the duplicate detector in some situation

Summary of changes in this PR:

- Fix to display a right number of items in the detail page of the duplicate detector in some situation

Additional commit notes for project team:

- When `DuplicateDetectorActivity` changes its lifecycle from `onPause` to `onResume`
 e.g) press items in the detail page and press back button, press home button and resume
- `DuplicateDetailsFragment` displays the wrong number in the title because `DuplicateDetectorActivity` has the observer.

<br />
@AVnetWS/admin-team
