### PR TITLE
Per-app language and Android 13 storage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ aboutLibraries {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
     compileOptions {
         targetCompatibility JavaVersion.VERSION_1_8
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -32,7 +32,7 @@ android {
     defaultConfig {
         applicationId "me.devsaki.hentoid"
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 130 // is updated automatically by BitRise; only used when building locally
         versionName '1.16.11'
 
@@ -92,6 +92,7 @@ android {
         informational 'ExtraTranslation'
     }
     namespace 'me.devsaki.hentoid'
+    buildToolsVersion '33.0.0'
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,7 +92,6 @@ android {
         informational 'ExtraTranslation'
     }
     namespace 'me.devsaki.hentoid'
-    buildToolsVersion '33.0.0'
 }
 
 dependencies {

--- a/app/customssiv/build.gradle
+++ b/app/customssiv/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-kapt'
 
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
     compileOptions {
         targetCompatibility JavaVersion.VERSION_1_8
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 33
 
         renderscriptTargetApi 21
         renderscriptSupportModeEnabled false

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         android:supportsRtl="false"
         android:theme="@style/Theme.Light"
         android:usesCleartextTraffic="true"
+        android:localeConfig="@xml/locales_config"
         tools:replace="android:allowBackup, android:supportsRtl, android:extractNativeLibs">
         <activity
             android:name=".activities.MissingWebViewActivity"

--- a/app/src/main/java/me/devsaki/hentoid/activities/IntroActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/IntroActivity.java
@@ -41,7 +41,8 @@ public class IntroActivity extends AppIntro2 {
         super.onCreate(savedInstanceState);
 
         addSlide(new WelcomeIntroFragment());
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             addSlide(new PermissionIntroFragment());
         }
         addSlide(new ImportIntroFragment());

--- a/app/src/main/java/me/devsaki/hentoid/activities/LibraryActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/LibraryActivity.java
@@ -17,6 +17,7 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.graphics.Typeface;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -357,7 +358,8 @@ public class LibraryActivity extends BaseActivity {
             TooltipHelper.showTooltip(this, R.string.help_search, ArrowOrientation.TOP, toolbar, this);
 
         // Display permissions alert if required
-        if (!PermissionHelper.checkExternalStorageReadWritePermission(this)) {
+        if (!PermissionHelper.checkExternalStorageReadWritePermission(this) &&
+                Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             alertTxt.setText(R.string.permissions_lost);
             alertFixBtn.setOnClickListener(v -> fixPermissions());
             alertTxt.setVisibility(View.VISIBLE);

--- a/app/src/main/java/me/devsaki/hentoid/activities/ReaderActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/ReaderActivity.java
@@ -3,6 +3,7 @@ package me.devsaki.hentoid.activities;
 import static me.devsaki.hentoid.util.file.PermissionHelper.RQST_STORAGE_PERMISSION;
 
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.WindowManager;
@@ -68,7 +69,8 @@ public class ReaderActivity extends BaseActivity {
             else viewModel.loadContentFromId(contentId, pageNumber);
         }
 
-        if (!PermissionHelper.requestExternalStorageReadPermission(this, RQST_STORAGE_PERMISSION)) {
+        if (!PermissionHelper.requestExternalStorageReadPermission(this, RQST_STORAGE_PERMISSION) &&
+                Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             ToastHelper.toast(R.string.storage_permission_denied);
             return;
         }

--- a/app/src/main/java/me/devsaki/hentoid/util/file/PermissionHelper.java
+++ b/app/src/main/java/me/devsaki/hentoid/util/file/PermissionHelper.java
@@ -2,6 +2,7 @@ package me.devsaki.hentoid.util.file;
 
 import android.Manifest;
 import android.app.Activity;
+import android.os.Build;
 
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
@@ -38,7 +39,7 @@ public class PermissionHelper {
     }
 
     public static boolean requestExternalStorageReadWritePermission(Activity activity, int permissionRequestCode) {
-        if (checkExternalStorageReadWritePermission(activity))
+        if (checkExternalStorageReadWritePermission(activity) | Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
             return true;
         else {
             ActivityCompat.requestPermissions(activity, new String[]{

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en"/>
+    <locale android:name="es"/>
+    <locale android:name="hu"/>
+    <locale android:name="it"/>
+    <locale android:name="ja"/>
+    <locale android:name="ko"/>
+    <locale android:name="pt-rBR"/>
+    <locale android:name="ru"/>
+    <locale android:name="uk"/>
+</locale-config>


### PR DESCRIPTION
**Implements Feature:** Added per-app language support amd Android 13 SDK storage
<br />

Summary of changes in this PR:

- Added locale_config for per-app language support

- Skipping READ_EXTERNAL_STORAGE permission request for 33 SDK

Additional commit notes for project team:

- Due to permission READ_EXTERNAL_STORAGE being split into 3 others in sdk 33, Hentoid was unable to get this permission when migrating to sdk 33 to support config_locale. Now the application can access the memory through the system file manager.

<br />
@AVnetWS/admin-team
