### PR TITLE
Make Coroutine works like old RxJava

### DIFF
--- a/app/src/main/java/me/devsaki/hentoid/fragments/intro/ImportIntroFragment.kt
+++ b/app/src/main/java/me/devsaki/hentoid/fragments/intro/ImportIntroFragment.kt
@@ -13,8 +13,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.devsaki.hentoid.R
 import me.devsaki.hentoid.activities.IntroActivity
@@ -114,7 +114,8 @@ class ImportIntroFragment : Fragment(R.layout.intro_slide_04) {
                 val animation = BlinkAnimation(750, 20)
                 binding.waitTxt.startAnimation(animation)
 
-                runBlocking {
+                val scope = CoroutineScope(Dispatchers.Main)
+                scope.launch {
                     val result = withContext(Dispatchers.IO) {
                         setAndScanPrimaryFolder(
                             requireContext(),
@@ -124,11 +125,9 @@ class ImportIntroFragment : Fragment(R.layout.intro_slide_04) {
                             null
                         )
                     }
-                    coroutineScope {
-                        binding.waitTxt.clearAnimation()
-                        binding.waitTxt.visibility = View.GONE
-                        onScanHentoidFolderResult(result.left, result.right)
-                    }
+                    binding.waitTxt.clearAnimation()
+                    binding.waitTxt.visibility = View.GONE
+                    onScanHentoidFolderResult(result.left, result.right)
                 }
             }
 


### PR DESCRIPTION
**Fixes issue** : Make Coroutine works like old RxJava
<br />

Summary of changes in this PR:

- Make Coroutine works like old RxJava

Additional commit notes for project team:

- A Coroutine in `ImportIntroFragment.kt`  works slightly different way than an old RxJava (commit : e1232a982131ca331914108d04aedc5757064429 )

It makes crash when selecting empty folder as a Hentoid folder because of LifeCycle related problem.

It also makes a black screen when selecting folder already exist Hentoid folder because of `runBlocking`
e.g) An old RxJava works like 
(select folder -> back to app -> show user 'please wait' -> do next works)
A Coroutine with runBlocking works like 
(select folder -> show black screen -> back to app -> do next works)
<br />
@AVnetWS/admin-team
