### PR TITLE
Browser: Language filter button for hitomi

### DIFF
--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/BaseWebActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/BaseWebActivity.java
@@ -42,6 +42,7 @@ import androidx.core.util.Pair;
 import com.annimon.stream.Optional;
 import com.annimon.stream.Stream;
 import com.annimon.stream.function.BiConsumer;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.skydoves.balloon.ArrowOrientation;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -191,6 +192,7 @@ public abstract class BaseWebActivity extends BaseActivity implements CustomWebV
     private MenuItem bookmarkMenu;
     private @DrawableRes
     int downloadIcon;
+    protected FloatingActionButton languageFilterButton;
 
     // === CURRENTLY VIEWED CONTENT-RELATED VARIABLES
     private Content currentContent = null;
@@ -265,7 +267,7 @@ public abstract class BaseWebActivity extends BaseActivity implements CustomWebV
         toolbar.setTitle(getStartSite().getDescription());
         refreshStopMenu = toolbar.getMenu().findItem(R.id.web_menu_refresh_stop);
         bookmarkMenu = toolbar.getMenu().findItem(R.id.web_menu_bookmark);
-
+        languageFilterButton = findViewById(R.id.language_filter_button);
         binding.bottomNavigation.setOnMenuItemClickListener(this::onMenuItemSelected);
         binding.menuHome.setOnClickListener(v -> goHome());
         binding.menuSeek.setOnClickListener(v -> onSeekClick());

--- a/app/src/main/java/me/devsaki/hentoid/util/Preferences.java
+++ b/app/src/main/java/me/devsaki/hentoid/util/Preferences.java
@@ -816,6 +816,14 @@ public final class Preferences {
         return getIntPref(Key.VIEWER_GALLERY_COLUMNS, Default.VIEWER_GALLERY_COLUMNS);
     }
 
+    public static boolean isLanguageFilterButton() {
+        return getBoolPref(Key.BROWSER_LANGUAGE_FILTER, Default.BROWSER_LANGUAGE_FILTER);
+    }
+
+    public static String getLanguageFilterButtonValue() {
+        return sharedPreferences.getString(Key.BROWSER_LANGUAGE_FILTER_VALUE, "english");
+    }
+
     public static final class Key {
 
         private Key() {
@@ -874,6 +882,8 @@ public final class Preferences {
         public static final String BROWSER_QUICK_DL_THRESHOLD = "pref_browser_quick_dl_threshold";
         public static final String BROWSER_DNS_OVER_HTTPS = "pref_browser_dns_over_https";
         public static final String BROWSER_CLEAR_COOKIES = "pref_browser_clear_cookies";
+        public static final String BROWSER_LANGUAGE_FILTER = "pref_browser_language_filter";
+        public static final String BROWSER_LANGUAGE_FILTER_VALUE = "pref_language_filter_value";
         public static final String BROWSER_NHENTAI_INVISIBLE_BLACKLIST = "pref_nhentai_invisible_blacklist";
         static final String FOLDER_TRUNCATION_LISTS = "pref_folder_trunc_lists";
         static final String VIEWER_RESUME_LAST_LEFT = "pref_viewer_resume_last_left";
@@ -991,6 +1001,7 @@ public final class Preferences {
         static final int BROWSER_QUICK_DL_THRESHOLD = 1500; // 1.5s
         static final int BROWSER_DNS_OVER_HTTPS = -1; // No DNS
         static final boolean BROWSER_NHENTAI_INVISIBLE_BLACKLIST = false;
+        static final boolean BROWSER_LANGUAGE_FILTER = false;
         static final int DL_THREADS_QUANTITY = Constant.DOWNLOAD_THREAD_COUNT_AUTO;
         static final int DL_HTTP_429_DEFAULT_DELAY = 10;
         static final int FOLDER_TRUNCATION = Constant.TRUNCATE_FOLDER_100;

--- a/app/src/main/res/layout/activity_base_web.xml
+++ b/app/src/main/res/layout/activity_base_web.xml
@@ -246,10 +246,22 @@
         android:layout_height="wrap_content"
         android:backgroundTint="?colorPrimaryDark"
         android:contentDescription="@string/menu_download_streamed"
-        android:visibility="gone"
+        android:visibility="invisible"
         android:layout_gravity="center_vertical|center"
         app:layout_anchor="@id/bottom_navigation"
         app:srcCompat="@drawable/selector_download_action"
+        tools:visibility="visible" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/language_filter_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:backgroundTint="?colorPrimaryDark"
+        android:visibility="gone"
+        android:layout_gravity="right"
+        android:layout_marginBottom="80dp"
+        app:layout_anchor="@id/action_button"
+        app:srcCompat="@drawable/ic_attribute_language"
         tools:visibility="visible" />
 
     <TextView

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -461,6 +461,7 @@
     <string name="pref_browser_override_overview_default" translatable="false">false</string>
     <string name="pref_browser_initial_zoom_default" translatable="false">20</string>
     <string name="pref_browser_dns_default" translatable="false">-1</string>
+    <string name="pref_browser_language_button_default" translatable="false">false</string>
     <!-- Strings: Settings: Downloader -->
     <string name="pref_queue_autostart_default" translatable="false">true</string>
     <string name="pref_queue_wifi_only_default" translatable="false">false</string>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -118,6 +118,11 @@
     <string name="pref_browser_clear_cookies_ko">No cookie to clear</string>
     <string name="pref_browser_clear_cookies_missing_webview">WebView is unavailable, can\'t clear cookies now</string>
     <string name="pref_browser_clear_cookies_updating_webview">WebView is updating right now, can\'t clear cookies yet</string>
+    <string name="pref_browser_language_filter_title">Language filter button</string>
+    <string name="pref_browser_language_filter_off">Language filter button is disabled\nNB: Only works on Hitomi</string>
+    <string name="pref_browser_language_filter_on">Language filter button is enabled\nNB: Only works on Hitomi</string>
+    <string name="pref_browser_language_filter_setting_title">Language filter setting</string>
+    <string name="pref_browser_language_filter_setting_summary">Tip: Enter the language in English</string>
 
     <!-- Downloader -->
     <string name="pref_screen_downloader">Downloader</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -189,6 +189,19 @@
                 android:summaryOn="@string/pref_browser_resume_last_on"
                 android:title="@string/pref_browser_resume_last_title"
                 app:iconSpaceReserved="false" />
+            <CheckBoxPreference
+                android:defaultValue="@string/pref_browser_language_button_default"
+                android:key="pref_browser_language_filter"
+                android:summaryOff="@string/pref_browser_language_filter_off"
+                android:summaryOn="@string/pref_browser_language_filter_on"
+                android:title="@string/pref_browser_language_filter_title"
+                app:iconSpaceReserved="false" />
+            <EditTextPreference
+                android:dependency="pref_browser_language_filter"
+                android:key="pref_language_filter_value"
+                android:summary="@string/pref_browser_language_filter_setting_summary"
+                android:title="@string/pref_browser_language_filter_setting_title"
+                app:iconSpaceReserved="false" />
         </PreferenceCategory>
         <PreferenceCategory
             android:title="@string/pref_browser_duplicate_detector"


### PR DESCRIPTION
**Implements Feature:** Language filter button for Hitomi
<br />

Summary of changes in this PR:

- Language filter button helps users browse their wanted language only.

Additional commit notes for project team:
- Only works on Hitomi

- In the case user want to browse contents in English only,
   3 steps was needed before
   1. press right-top menu button
   2. press language
   3. press English  
   
   But with Language filter button, only 1 step is needed.

- The button only visible in 1st page only to prevent disrupting browsing
  e.g) visible in /artist/artistName-all.html 
         invisible in /artist/artistName-all.html?page=2

- The button only visible if current url is showing "all" language contents
e.g) invisible in /artist/artistName-english.html

<br />
@AVnetWS/admin-team
