### PR TITLE
Pixiv : Support removing ad space, marking downloaded books

### DIFF
--- a/app/src/main/assets/pixiv.css
+++ b/app/src/main/assets/pixiv.css
@@ -1,0 +1,6 @@
+/* Custom style to hide ad space */
+
+/* element containing ad space */
+.banner-ad-footer-scale, .ad-frame-container, .ad-container {
+    display:none;
+}

--- a/app/src/main/assets/pixiv.js
+++ b/app/src/main/assets/pixiv.js
@@ -1,8 +1,71 @@
 document.addEventListener("DOMContentLoaded", function () {
+    addCustomCss();
+
+    if (document.URL.includes(".php")) {
+        markBooksPhp()
+
+    } else {
+        markBooks();
+    }
+
+});
+
+function addCustomCss() {
     var customCss = document.createElement("style");
 
     customCss.setAttribute("type", "text/css");
     customCss.textContent = pixivJsInterface.getPixivCustomCss();
 
     document.head.append(customCss);
-});
+}
+
+function markBooks() {
+    var observerTarget = document.querySelector("div#wrapper");
+    var observer = new MutationObserver((mutations) => {
+        for (let i of mutations) {
+            var target = i.addedNodes[0];
+
+            if (typeof (target) != 'undefined') {
+                if (target.nodeType == 1) {
+                    targetClassAttr = target.getAttribute("class");
+                    if ((targetClassAttr == "thumb") || (targetClassAttr == "thumbnail-link")) {
+                        var markTarget = target.closest("a[href]");
+                        var targetBookId = markTarget.getAttribute("href").replace("/en", '').replace("/a", "a").concat("/");
+                        var result = pixivJsInterface.isMarkable(targetBookId);
+                        if (result == 1) {
+                            markTarget.classList.add('watermarked');
+                        } else if (result == 2) {
+                            markTarget.classList.add("watermarked-merged");
+                        }
+                    } else if ((targetClassAttr == "works-item-illust works-item grid no-padding")) {
+                        var markTarget = target.firstChild;
+                        if (pixivJsInterface.isMarkable(markTarget.getAttribute("href"))) {
+                            markTarget.classList.add('watermarked');
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    var option = {
+        childList: true,
+        subtree: true
+    };
+
+    observer.observe(observerTarget, option);
+}
+
+function markBooksPhp() {
+    var markTargets = document.querySelectorAll(".imgbox");
+
+    for (let markTarget of markTargets) {
+        var targetBookId = markTarget.firstChild.getAttribute("href").replace("/en", '').replace("/a", "a").concat("/");
+        var result = pixivJsInterface.isMarkable(targetBookId);
+        if (result == 1) {
+            markTarget.classList.add('watermarked');
+        } else if (result == 2) {
+            markTarget.classList.add("watermarked-merged");
+        }
+    }
+}

--- a/app/src/main/assets/pixiv.js
+++ b/app/src/main/assets/pixiv.js
@@ -1,0 +1,8 @@
+document.addEventListener("DOMContentLoaded", function () {
+    var customCss = document.createElement("style");
+
+    customCss.setAttribute("type", "text/css");
+    customCss.textContent = pixivJsInterface.getPixivCustomCss();
+
+    document.head.append(customCss);
+});

--- a/app/src/main/assets/pixiv.js
+++ b/app/src/main/assets/pixiv.js
@@ -3,7 +3,6 @@ document.addEventListener("DOMContentLoaded", function () {
 
     if (document.URL.includes(".php")) {
         markBooksPhp()
-
     } else {
         markBooks();
     }
@@ -30,18 +29,11 @@ function markBooks() {
                     targetClassAttr = target.getAttribute("class");
                     if ((targetClassAttr == "thumb") || (targetClassAttr == "thumbnail-link")) {
                         var markTarget = target.closest("a[href]");
-                        var targetBookId = markTarget.getAttribute("href").replace("/en", '').replace("/a", "a").concat("/");
-                        var result = pixivJsInterface.isMarkable(targetBookId);
-                        if (result == 1) {
-                            markTarget.classList.add('watermarked');
-                        } else if (result == 2) {
-                            markTarget.classList.add("watermarked-merged");
-                        }
                     } else if ((targetClassAttr == "works-item-illust works-item grid no-padding")) {
                         var markTarget = target.firstChild;
-                        if (pixivJsInterface.isMarkable(markTarget.getAttribute("href"))) {
-                            markTarget.classList.add('watermarked');
-                        }
+                    }
+                    if (typeof (markTarget) != 'undefined') {
+                        markBook(markTarget);
                     }
                 }
             }
@@ -57,15 +49,27 @@ function markBooks() {
 }
 
 function markBooksPhp() {
-    var markTargets = document.querySelectorAll(".imgbox");
+    var targets = document.querySelectorAll(".imgbox");
 
-    for (let markTarget of markTargets) {
-        var targetBookId = markTarget.firstChild.getAttribute("href").replace("/en", '').replace("/a", "a").concat("/");
-        var result = pixivJsInterface.isMarkable(targetBookId);
-        if (result == 1) {
-            markTarget.classList.add('watermarked');
-        } else if (result == 2) {
-            markTarget.classList.add("watermarked-merged");
+    for (let target of targets) {
+        var markTarget = target.firstChild;
+        markBook(markTarget);
+    }
+}
+
+function markBook(markTarget) {
+    var targetBookId = markTarget.getAttribute("href").replace("/en", '').replace("/a", "a").concat("/");
+    var result = pixivJsInterface.isMarkable(targetBookId);
+    if (result == 1) {
+        markTarget.classList.add('watermarked');
+    } else if (result == 2) {
+        markTarget.classList.add("watermarked-merged");
+    } else {
+        var classList = markTarget.classList;
+        if (classList.contains("watermarked")) {
+            markTarget.classList.remove("watermarked");
+        } else if (classList.contains("watermarked-merged")) {
+            markTarget.classList.remove("watermarked-merged");
         }
     }
 }

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/BaseWebActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/BaseWebActivity.java
@@ -1573,7 +1573,7 @@ public abstract class BaseWebActivity extends BaseActivity implements CustomWebV
                 FileHelper.getAssetAsString(getAssets(), "nhentai_invisible_blacklist.css", sb);
             if (getStartSite().equals(Site.IMHENTAI))
                 FileHelper.getAssetAsString(getAssets(), "imhentai.css", sb);
-            if (getStartSite().equals(Site.PIXIV))
+            if (getStartSite().equals(Site.PIXIV) && Preferences.isBrowserAugmented())
                 FileHelper.getAssetAsString(getAssets(), "pixiv.css", sb);
             customCss = sb.toString();
         }

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/BaseWebActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/BaseWebActivity.java
@@ -1573,6 +1573,8 @@ public abstract class BaseWebActivity extends BaseActivity implements CustomWebV
                 FileHelper.getAssetAsString(getAssets(), "nhentai_invisible_blacklist.css", sb);
             if (getStartSite().equals(Site.IMHENTAI))
                 FileHelper.getAssetAsString(getAssets(), "imhentai.css", sb);
+            if (getStartSite().equals(Site.PIXIV))
+                FileHelper.getAssetAsString(getAssets(), "pixiv.css", sb);
             customCss = sb.toString();
         }
         return customCss;

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/PixivActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/PixivActivity.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import io.reactivex.Completable;
@@ -130,6 +131,21 @@ public class PixivActivity extends BaseWebActivity {
         @SuppressWarnings("unused")
         public String getPixivCustomCss() {
             return getCustomCss();
+        }
+
+        @JavascriptInterface
+        @SuppressWarnings("unused")
+        public int isMarkable(String bookId) {
+
+            List<String> downloadedBooks = getAllSiteUrls();
+            List<String> mergedBooks = getAllMergedBooksUrls();
+
+            if (downloadedBooks.contains(bookId))
+                return 1;
+            else if (mergedBooks.contains(bookId))
+                return 2;
+            else
+                return 0;
         }
     }
 }

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/PixivActivity.java
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/PixivActivity.java
@@ -1,5 +1,6 @@
 package me.devsaki.hentoid.activities.sources;
 
+import android.webkit.JavascriptInterface;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
@@ -49,6 +50,8 @@ public class PixivActivity extends BaseWebActivity {
         PixivWebClient client = new PixivWebClient(getStartSite(), GALLERY_FILTER, this);
         client.adBlocker.addToUrlBlacklist(BLOCKED_CONTENT);
         client.adBlocker.addToJsUrlWhitelist(JS_WHITELIST);
+        client.setJsStartupScripts("pixiv.js");
+        webView.addJavascriptInterface(new pixivJsInterface(), "pixivJsInterface");
 
         return client;
     }
@@ -119,6 +122,14 @@ public class PixivActivity extends BaseWebActivity {
                 );
             }
             return null;
+        }
+    }
+
+    public class pixivJsInterface {
+        @JavascriptInterface
+        @SuppressWarnings("unused")
+        public String getPixivCustomCss() {
+            return getCustomCss();
         }
     }
 }

--- a/app/src/main/res/layout/activity_base_web.xml
+++ b/app/src/main/res/layout/activity_base_web.xml
@@ -172,7 +172,7 @@
         android:layout_width="match_parent"
         android:layout_height="?android:attr/actionBarSize"
         android:layout_gravity="bottom"
-        android:background="?colorPrimary"
+        android:backgroundTint="?colorPrimary"
         app:layout_behavior="me.devsaki.hentoid.widget.BottomNavigationBehaviour">
 
         <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
 **Implements Feature:** Support removing ad space, marking downloaded books on Pixiv, UI fix
<br />

Summary of changes in this PR:

- Hide ad space in Pixiv

- Support marking downloaded books in Pixiv

- Use backgroundTint in BottomAppBar

Additional commit notes for project team:

- Use `MutationObserver` because the images of Pixiv is loaded dynamically.

- Using `android:background` in BottomAppbar can't affect its color.(https://developer.android.com/reference/com/google/android/material/bottomappbar/BottomAppBar)

<br />
@AVnetWS/admin-team
