### PR TITLE
Fix image sharing intent type

### DIFF
--- a/app/src/main/java/me/devsaki/hentoid/fragments/reader/ReaderImageBottomSheetFragment.kt
+++ b/app/src/main/java/me/devsaki/hentoid/fragments/reader/ReaderImageBottomSheetFragment.kt
@@ -262,7 +262,8 @@ class ReaderImageBottomSheetFragment : BottomSheetDialogFragment() {
             if (FileHelper.fileExists(requireContext(), fileUri)) FileHelper.shareFile(
                 requireContext(),
                 fileUri,
-                ""
+                "",
+                "image/*"
             )
         }
     }

--- a/app/src/main/java/me/devsaki/hentoid/util/file/FileHelper.java
+++ b/app/src/main/java/me/devsaki/hentoid/util/file/FileHelper.java
@@ -694,8 +694,21 @@ public class FileHelper {
      * @param title   Title of the user dialog
      */
     public static void shareFile(final @NonNull Context context, final @NonNull Uri fileUri, final @NonNull String title) {
+
+        shareFile(context, fileUri, title, "text/*");
+    }
+
+    /**
+     * Share the given file using the device's app(s) of choice
+     *
+     * @param context Context to use
+     * @param fileUri Uri of the file to share
+     * @param title   Title of the user dialog
+     * @param type    The type to use for the sharing intent
+     */
+    public static void shareFile(final @NonNull Context context, final @NonNull Uri fileUri, final @NonNull String title, final @NonNull String type) {
         Intent sharingIntent = new Intent(Intent.ACTION_SEND);
-        sharingIntent.setType("text/*");
+        sharingIntent.setType(type);
         if (!title.isEmpty()) sharingIntent.putExtra(Intent.EXTRA_SUBJECT, title);
         if (fileUri.toString().startsWith("file")) {
             Uri legitUri = FileProvider.getUriForFile(context, AUTHORITY, new File(fileUri.toString()));


### PR DESCRIPTION
It should now show more apps relevant to image and stop showing irrelevant apps in the share menu

**Implements Feature:** Show more relevant apps for image sharing, eg: Lens (for translating)
<br />

Summary of changes in this PR:

Add overloading method to shareFile to be able to change the intent typing (backward compatibility and minimizing change)

Change the share button in the viewer to use type of 'image/*' instead of 'text/*'

Additional commit notes for project team:

Regarding #504, share now include print and other apps that include feature that can turn a single image to pdf
but that's probably not the intent of #504

@AVnetWS/admin-team
