### PR TITLE
Browser : Mark queued books

### DIFF
--- a/app/src/main/assets/downloaded.css
+++ b/app/src/main/assets/downloaded.css
@@ -72,3 +72,28 @@
   z-index:auto;
   pointer-events: none;
 }
+
+/* Custom styles to mark queued books*/
+.watermarked-queued {
+
+}
+
+.watermarked-queued img {
+  filter: grayscale(100%) opacity(25%);
+}
+
+.watermarked-queued:after {
+  content: "";
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  background-image: url("https://bogus.com/hentoid-queuedmark.webp");
+  background-size: 75px 75px;
+  background-position: 50% 50%;
+  background-repeat: no-repeat;
+  z-index:auto;
+  pointer-events: none;
+}

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/EHentaiActivity.kt
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/EHentaiActivity.kt
@@ -85,7 +85,7 @@ class EHentaiActivity : BaseWebActivity() {
                     }
                 }
             }
-            return if (isMarkDownloaded() || isMarkMerged() || isMarkBlockedTags())
+            return if (isMarkDownloaded() || isMarkMerged() || isMarkBlockedTags() || isMarkQueued())
                 super.parseResponse(
                     url,
                     requestHeaders,

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/ExHentaiActivity.kt
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/ExHentaiActivity.kt
@@ -117,7 +117,7 @@ class ExHentaiActivity : BaseWebActivity() {
                     }
                 }
             }
-            return if (isMarkDownloaded() || isMarkMerged() || isMarkBlockedTags())
+            return if (isMarkDownloaded() || isMarkMerged() || isMarkBlockedTags() || isMarkQueued())
                 super.parseResponse(
                     url,
                     requestHeaders,

--- a/app/src/main/java/me/devsaki/hentoid/activities/sources/HitomiActivity.kt
+++ b/app/src/main/java/me/devsaki/hentoid/activities/sources/HitomiActivity.kt
@@ -175,7 +175,7 @@ class HitomiActivity : BaseWebActivity() {
             request: WebResourceRequest
         ): WebResourceResponse? {
             val url = request.url.toString()
-            if ((isMarkDownloaded() || isMarkMerged() || isMarkBlockedTags()) && url.contains("galleryblock")) { // Process book blocks to mark existing ones
+            if ((isMarkDownloaded() || isMarkMerged() || isMarkBlockedTags() || isMarkQueued()) && url.contains("galleryblock")) { // Process book blocks to mark existing ones
                 val result = parseResponse(
                     url, request.requestHeaders,
                     analyzeForDownload = false,

--- a/app/src/main/java/me/devsaki/hentoid/database/CollectionDAO.kt
+++ b/app/src/main/java/me/devsaki/hentoid/database/CollectionDAO.kt
@@ -240,6 +240,8 @@ interface CollectionDAO {
 
     fun selectQueueLive(query: String?, source: Site?): LiveData<List<QueueRecord>>
 
+    fun selectQueueUrls(site: Site): Set<String>
+
     fun addContentToQueue(
         content: Content,
         sourceImageStatus: StatusContent?,

--- a/app/src/main/java/me/devsaki/hentoid/database/DatabaseMaintenance.kt
+++ b/app/src/main/java/me/devsaki/hentoid/database/DatabaseMaintenance.kt
@@ -53,6 +53,18 @@ object DatabaseMaintenance {
     }
 
     private fun cleanContent(context: Context, emitter: (Float) -> Unit) {
+        val mdb = MaintenanceDAO()
+        try {
+            // Remove empty QueueRecords from the queue (still not sure how they appear in the first place)
+            Timber.i("Removing orphan Queue records : start")
+            val orphanIds = mdb.selectOrphanQueueRecordIds()
+            Timber.i("Removing orphan Queue records : %s items detected", orphanIds.size)
+            mdb.deleteQueueRecords(orphanIds)
+            Timber.i("Removing orphan Queue records : done")
+        } finally {
+            mdb.cleanup()
+        }
+
         try {
             // Set items that were being downloaded in previous session as paused
             Timber.i("Updating queue status : start")
@@ -91,18 +103,6 @@ object DatabaseMaintenance {
             Timber.i("Moving back isolated items to queue : done")
         } finally {
             ObjectBoxDB.cleanup()
-        }
-
-        val mdb = MaintenanceDAO()
-        try {
-            // Remove empty QueueRecords from the queue (still not sure how they appear in the first place)
-            Timber.i("Removing orphan Queue records : start")
-            val orphanIds = mdb.selectOrphanQueueRecordIds()
-            Timber.i("Removing orphan Queue records : %s items detected", orphanIds.size)
-            mdb.deleteQueueRecords(orphanIds)
-            Timber.i("Removing orphan Queue records : done")
-        } finally {
-            mdb.cleanup()
         }
     }
 

--- a/app/src/main/java/me/devsaki/hentoid/database/ObjectBoxDAO.kt
+++ b/app/src/main/java/me/devsaki/hentoid/database/ObjectBoxDAO.kt
@@ -1060,6 +1060,10 @@ class ObjectBoxDAO : CollectionDAO {
         return ObjectBoxDB.selectQueueRecordsQ().safeFind()
     }
 
+    override fun selectQueueUrls(site: Site): Set<String> {
+        return ObjectBoxDB.selectQueueUrls(site)
+    }
+
     override fun updateQueue(queue: List<QueueRecord>) {
         ObjectBoxDB.updateQueue(queue)
     }

--- a/app/src/main/java/me/devsaki/hentoid/database/ObjectBoxDB.kt
+++ b/app/src/main/java/me/devsaki/hentoid/database/ObjectBoxDB.kt
@@ -270,6 +270,19 @@ object ObjectBoxDB {
             }.build()
     }
 
+    fun selectQueueUrls(site: Site): HashSet<String> {
+        store.boxFor(Content::class.java).query()
+            .`in`(Content_.status, getQueueStatuses())
+            .equal(Content_.site, site.code.toLong())
+            .filter { c: Content ->
+                StatusContent.ERROR == c.status || c.queueRecords != null && !c.queueRecords!!
+                    .isEmpty()
+            }
+            .build().use { qb ->
+                return qb.property(Content_.dbUrl).findStrings().toHashSet()
+            }
+    }
+
     fun selectAllFlaggedBooksQ(): Query<Content> {
         return store.boxFor(Content::class.java).query()
             .equal(Content_.isFlaggedForDeletion, true).build()

--- a/app/src/main/java/me/devsaki/hentoid/util/Preferences.java
+++ b/app/src/main/java/me/devsaki/hentoid/util/Preferences.java
@@ -348,6 +348,10 @@ public final class Preferences {
         return getBoolPref(Key.BROWSER_MARK_MERGED, Default.BROWSER_MARK_MERGED);
     }
 
+    public static boolean isBrowserMarkQueued() {
+        return getBoolPref(Key.BROWSER_MARK_QUEUED, Default.BROWSER_MARK_QUEUED);
+    }
+
     public static boolean isBrowserMarkBlockedTags() {
         return getBoolPref(Key.BROWSER_MARK_BLOCKED, Default.BROWSER_MARK_BLOCKED);
     }
@@ -830,6 +834,7 @@ public final class Preferences {
         static final String BROWSER_RESUME_LAST = "pref_browser_resume_last";
         public static final String BROWSER_MARK_DOWNLOADED = "browser_mark_downloaded";
         public static final String BROWSER_MARK_MERGED = "browser_mark_merged";
+        public static final String BROWSER_MARK_QUEUED = "browser_mark_queued";
         public static final String BROWSER_MARK_BLOCKED = "browser_mark_blocked";
         public static final String BROWSER_DL_ACTION = "pref_browser_dl_action";
         public static final String BROWSER_QUICK_DL = "pref_browser_quick_dl";
@@ -946,6 +951,7 @@ public final class Preferences {
         static final boolean BROWSER_RESUME_LAST = false;
         static final boolean BROWSER_MARK_DOWNLOADED = false;
         static final boolean BROWSER_MARK_MERGED = false;
+        static final boolean BROWSER_MARK_QUEUED = false;
         static final boolean BROWSER_MARK_BLOCKED = false;
         static final int BROWSER_DL_ACTION = Constant.DL_ACTION_DL_PAGES;
         static final boolean BROWSER_QUICK_DL = true;

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -515,6 +515,7 @@
     <string name="pref_browser_duplicate_try_pages_default" translatable="false">true</string>
     <string name="pref_browser_mark_downloaded_default" translatable="false">false</string>
     <string name="pref_browser_mark_merged_default" translatable="false">false</string>
+    <string name="pref_browser_mark_queued_default" translatable="false">false</string>
     <string name="pref_browser_mark_blocked_default" translatable="false">false</string>
     <string name="pref_browser_force_lightmode_default" translatable="false">false</string>
     <string name="pref_browser_override_overview_default" translatable="false">false</string>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -106,6 +106,9 @@
     <string name="pref_browser_mark_merged_title">Mark merged books</string>
     <string name="pref_browser_mark_merged_off">Merged books have no special display</string>
     <string name="pref_browser_mark_merged_on">Merged books are marked\nNB: does not work on all sites</string>
+    <string name="pref_browser_mark_queued_title">Mark queued books</string>
+    <string name="pref_browser_mark_queued_off">Queued books have no special display</string>
+    <string name="pref_browser_mark_queued_on">Queued books are marked\nNB: does not work on all sites</string>
     <string name="pref_browser_mark_blocked_title">Mark books with blocked tags</string>
     <string name="pref_browser_mark_blocked_off">Books with blocked tags have no special display</string>
     <string name="pref_browser_mark_blocked_on">Books with blocked tags are marked\nNB: does not work on all sites</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -314,6 +314,13 @@
                 android:title="@string/pref_browser_mark_merged_title"
                 app:iconSpaceReserved="false" />
             <CheckBoxPreference
+                android:defaultValue="@string/pref_browser_mark_queued_default"
+                android:key="browser_mark_queued"
+                android:summaryOff="@string/pref_browser_mark_queued_off"
+                android:summaryOn="@string/pref_browser_mark_queued_on"
+                android:title="@string/pref_browser_mark_queued_title"
+                app:iconSpaceReserved="false" />
+            <CheckBoxPreference
                 android:defaultValue="@string/pref_browser_mark_blocked_default"
                 android:key="browser_mark_blocked"
                 android:summaryOff="@string/pref_browser_mark_blocked_off"


### PR DESCRIPTION
 **Implements Feature:** Mark queued books in browser

Summary of changes in this PR:

- New feature to mark queued books.

- Remove orphan queue first to prevent NPE

Additional commit notes for project team:

- Remove orphan queue before calling `selectQueueContents` to prevent NPE
<br />
@AVnetWS/admin-team
